### PR TITLE
Only store states for widgets with explicit IDs to improve performance

### DIFF
--- a/.changeset/chatty-points-occur.md
+++ b/.changeset/chatty-points-occur.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-framework": patch
+"@ensembleui/react-runtime": patch
+---
+
+Only store state for widgets with explicit ids

--- a/.changeset/rich-kiwis-switch.md
+++ b/.changeset/rich-kiwis-switch.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-framework": patch
+---
+
+Fix data context keys being overridden by undefined widget keys

--- a/apps/starter/craco.config.js
+++ b/apps/starter/craco.config.js
@@ -9,6 +9,10 @@ module.exports = {
             test: /\.yaml$/i,
             type: "asset/source",
           },
+          {
+            resourceQuery: /raw/,
+            type: "asset/source",
+          },
         ],
       },
       resolve: {

--- a/apps/starter/src/ensemble/screens/usersAndGroups.yaml
+++ b/apps/starter/src/ensemble/screens/usersAndGroups.yaml
@@ -6,6 +6,7 @@ View:
         executeCode: 
           body: |
             // ensemble.storage.set("arrayOfUsers",response.body.records)
+            console.log("bye")
             const groups = new Set(response.body.records.flatMap(record => record.fields.groups))
             // ensemble.storage.set("arrayOfGroups", Array.from(groups))
           onComplete:

--- a/apps/starter/src/index.tsx
+++ b/apps/starter/src/index.tsx
@@ -7,9 +7,9 @@ import reportWebVitals from "./reportWebVitals";
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = createRoot(document.getElementById("root")!);
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <App />,
+  // </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/packages/framework/src/evaluate.ts
+++ b/packages/framework/src/evaluate.ts
@@ -35,7 +35,7 @@ export const buildEvaluateFn = (
 
   // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
   const jsFunc = new Function(
-    ...[...Object.keys(invokableObj)],
+    ...Object.keys(invokableObj),
     addGlobalBlock(formatJs(js), globalBlock),
   );
 

--- a/packages/framework/src/hooks/useRegisterBindings.ts
+++ b/packages/framework/src/hooks/useRegisterBindings.ts
@@ -1,6 +1,6 @@
 import type { RefCallback } from "react";
 import { useEffect, useMemo } from "react";
-import { compact, merge, set } from "lodash-es";
+import { compact, isEmpty, merge, set } from "lodash-es";
 import isEqual from "react-fast-compare";
 import { atom, useAtom } from "jotai";
 import type { InvokableMethods } from "../state";
@@ -63,6 +63,11 @@ export const useRegisterBindings = <T extends Record<string, unknown>>(
 
   const newValues = merge({}, values, bindings) as T;
   useEffect(() => {
+    // Improves performance greatly: o need to store state in global if there's no explicit ID to reference it with
+    if (isEmpty(id)) {
+      return;
+    }
+
     if (
       isEqual(newValues, widgetState?.values) &&
       isEqual(methods, widgetState?.invokable.methods)
@@ -81,11 +86,12 @@ export const useRegisterBindings = <T extends Record<string, unknown>>(
     newValues,
     widgetState?.values,
     widgetState?.invokable.methods,
+    id,
   ]);
 
   return {
     id: resolvedWidgetId,
-    values: widgetState?.values,
+    values: widgetState?.values ?? newValues,
     rootRef,
   };
 };

--- a/packages/framework/src/hooks/useScreenContext.tsx
+++ b/packages/framework/src/hooks/useScreenContext.tsx
@@ -48,7 +48,9 @@ export const ScreenContextProvider: React.FC<ScreenContextProviderProps> = ({
             {
               app: appContext.application,
               model: screen,
-              inputs: Object.fromEntries(location.searchParams ?? []),
+              inputs: Object.fromEntries(
+                location.searchParams?.entries() ?? [],
+              ),
             },
             context,
           ) as ScreenContextDefinition

--- a/packages/framework/src/hooks/useWidgetState.ts
+++ b/packages/framework/src/hooks/useWidgetState.ts
@@ -1,24 +1,13 @@
 import { useAtom } from "jotai";
-import { focusAtom } from "jotai-optics";
-import { useMemo } from "react";
-import type { WidgetState, ScreenContextDefinition } from "../state";
-import { screenAtom } from "../state";
+import type { WidgetState } from "../state";
+import { widgetFamilyAtom } from "../state";
 
 export const useWidgetState = <T extends Record<string, unknown>>(
   id: string,
 ): [WidgetState<T> | undefined, (state: WidgetState<T>) => void] => {
-  const widgetStateAtom = useMemo(
-    () =>
-      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-      focusAtom<ScreenContextDefinition, WidgetState<T> | undefined, void>(
-        screenAtom,
-        // Generic typing is too complex here to properly type
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
-        (optic) => optic.path("widgets", id) as any,
-      ),
-    [id],
-  );
-
-  const widgetState = useAtom(widgetStateAtom);
-  return widgetState;
+  const widgetState = useAtom(widgetFamilyAtom(id));
+  return widgetState as [
+    WidgetState<T> | undefined,
+    (state: WidgetState<T>) => void,
+  ];
 };

--- a/packages/framework/src/state/screen.ts
+++ b/packages/framework/src/state/screen.ts
@@ -1,7 +1,13 @@
-import { atom } from "jotai";
+import { atom, useAtom, useAtomValue } from "jotai";
 import { focusAtom } from "jotai-optics";
+import { clone } from "lodash-es";
+import { useCallback } from "react";
 import type { Response } from "../data";
-import type { EnsembleAppModel, EnsembleScreenModel } from "../shared";
+import type {
+  EnsembleAPIModel,
+  EnsembleAppModel,
+  EnsembleScreenModel,
+} from "../shared";
 import type { WidgetState } from "./widget";
 
 export interface ScreenContextDefinition {
@@ -31,3 +37,29 @@ export const screenAtom = atom<ScreenContextDefinition>(defaultScreenContext);
 export const screenDataAtom = focusAtom(screenAtom, (optic) =>
   optic.prop("data"),
 );
+
+export const screenApiAtom = focusAtom(screenAtom, (optic) => {
+  return optic.prop("model").optional().prop("apis");
+});
+
+export const useScreenData = (): { apis?: EnsembleAPIModel[] } & Pick<
+  ScreenContextDefinition,
+  "data"
+> &
+  Pick<ScreenContextActions, "setData"> => {
+  const apis = useAtomValue(screenApiAtom);
+  const [data, setDataAtom] = useAtom(screenDataAtom);
+
+  const setData = useCallback(
+    (name: string, response: Response) => {
+      data[name] = response;
+      setDataAtom(clone(data));
+    },
+    [setDataAtom],
+  );
+  return {
+    apis,
+    data,
+    setData,
+  };
+};

--- a/packages/framework/src/state/widget.ts
+++ b/packages/framework/src/state/widget.ts
@@ -3,6 +3,7 @@ import { focusAtom } from "jotai-optics";
 import type { Atom } from "jotai";
 import { atom } from "jotai";
 import { isNil, merge, omitBy } from "lodash-es";
+import { atomFamily } from "jotai/utils";
 import type { Expression } from "../shared";
 import { isExpression, sanitizeJs, debug, error } from "../shared";
 import { evaluate } from "../evaluate";
@@ -18,6 +19,10 @@ export interface Invokable {
   id: string;
   methods?: InvokableMethods;
 }
+
+export const widgetFamilyAtom = atomFamily((id: string) =>
+  focusAtom(screenAtom, (optics) => optics.path("widgets", id)),
+);
 
 export const createBindingAtom = (
   expression?: Expression<unknown>,
@@ -56,9 +61,7 @@ export const createBindingAtom = (
   const dependencyEntries = identifiers.map((identifier) => {
     debug(`found dependency for ${String(widgetId)}: ${identifier}`);
     // TODO: Account for data bindings also
-    const dependencyAtom = focusAtom(screenAtom, (optic) =>
-      optic.path("widgets", identifier),
-    );
+    const dependencyAtom = widgetFamilyAtom(identifier);
     return { name: identifier, dependencyAtom };
   });
 

--- a/packages/framework/src/state/widget.ts
+++ b/packages/framework/src/state/widget.ts
@@ -2,7 +2,7 @@ import { parseExpressionAt, tokTypes } from "acorn";
 import { focusAtom } from "jotai-optics";
 import type { Atom } from "jotai";
 import { atom } from "jotai";
-import { merge } from "lodash-es";
+import { isNil, merge, omitBy } from "lodash-es";
 import type { Expression } from "../shared";
 import { isExpression, sanitizeJs, debug, error } from "../shared";
 import { evaluate } from "../evaluate";
@@ -74,7 +74,7 @@ export const createBindingAtom = (
       return [name, value?.values];
     });
     const evaluationContext = merge(
-      Object.fromEntries(valueEntries),
+      omitBy(Object.fromEntries(valueEntries), isNil),
       context,
     ) as Record<string, unknown>;
     try {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -36,7 +36,6 @@
     "chart.js": "^4.4.0",
     "chartjs-plugin-datalabels": "^2.2.0",
     "eslint-config-custom": "workspace:*",
-    "jest": "27.5.1",
     "lodash-es": "^4.17.21",
     "react-chartjs-2": "^5.2.0",
     "react-markdown": "^8.0.7",

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -96,6 +96,7 @@ export const useInvokeApi: EnsembleActionHook<InvokeAPIAction> = (action) => {
 
   const [response, setResponse] = useState<Response>();
   const [error, setError] = useState<unknown>();
+  const [isComplete, setIsComplete] = useState(false);
 
   const invokeApi = useMemo(() => {
     if (!screenContext?.model || !action) {
@@ -135,21 +136,23 @@ export const useInvokeApi: EnsembleActionHook<InvokeAPIAction> = (action) => {
 
   const onResponseAction = useEnsembleAction(action?.onResponse);
   useEffect(() => {
-    if (!response) {
+    if (!response || isComplete) {
       return;
     }
 
     onResponseAction?.callback({ response });
-  }, [action?.onResponse, onResponseAction, response]);
+    setIsComplete(true);
+  }, [isComplete, onResponseAction, response]);
 
   const onErrorAction = useEnsembleAction(action?.onError);
   useEffect(() => {
-    if (!error) {
+    if (!error || isComplete) {
       return;
     }
 
     onErrorAction?.callback({ error });
-  }, [action?.onError, error, onErrorAction]);
+    setIsComplete(true);
+  }, [error, isComplete, onErrorAction]);
 
   return invokeApi;
 };

--- a/packages/runtime/src/widgets/GridView.tsx
+++ b/packages/runtime/src/widgets/GridView.tsx
@@ -8,6 +8,7 @@ import {
   useTemplateData,
 } from "@ensembleui/react-framework";
 import { Col, Row } from "antd";
+import { useMemo } from "react";
 import { WidgetRegistry } from "../registry";
 import { EnsembleRuntime } from "../runtime";
 import type {
@@ -36,49 +37,58 @@ export const GridView: React.FC<GridViewProps> = ({
   const defaultColumnCount = 4;
   const { namedData } = useTemplateData({ data, name });
 
-  const rows = [];
-  const colCount = styles?.horizontalTileCount ?? defaultColumnCount;
-  const rowCount = Math.ceil(namedData.length / colCount);
+  const rows = useMemo(() => {
+    const workingRows = [];
+    const colCount = styles?.horizontalTileCount ?? defaultColumnCount;
+    const rowCount = Math.ceil(namedData.length / colCount);
 
-  for (let i = 0; i < rowCount; i++) {
-    const cols = [];
-    for (let j = 0; j < colCount; j++) {
-      const dataIndex = i * colCount + j;
-      if (dataIndex < namedData.length)
-        cols.push(
-          <Col
-            key={dataIndex}
-            style={{
-              display: "flex",
-              flexGrow: 1,
-              justifyContent: "center",
-              marginLeft: (styles?.horizontalGap ?? 20) / 2,
-              marginRight: (styles?.horizontalGap ?? 20) / 2,
-              maxWidth: `calc(100% / ${styles?.horizontalTileCount ?? 4} - ${
-                styles?.horizontalGap ?? 20
-              }px)`,
-            }}
-          >
-            <CustomScopeProvider value={namedData[dataIndex] as CustomScope}>
-              {EnsembleRuntime.render([template])}
-            </CustomScopeProvider>
-          </Col>,
-        );
+    for (let i = 0; i < rowCount; i++) {
+      const cols = [];
+      for (let j = 0; j < colCount; j++) {
+        const dataIndex = i * colCount + j;
+        if (dataIndex < namedData.length)
+          cols.push(
+            <Col
+              key={dataIndex}
+              style={{
+                display: "flex",
+                flexGrow: 1,
+                justifyContent: "center",
+                marginLeft: (styles?.horizontalGap ?? 20) / 2,
+                marginRight: (styles?.horizontalGap ?? 20) / 2,
+                maxWidth: `calc(100% / ${styles?.horizontalTileCount ?? 4} - ${
+                  styles?.horizontalGap ?? 20
+                }px)`,
+              }}
+            >
+              <CustomScopeProvider value={namedData[dataIndex] as CustomScope}>
+                {EnsembleRuntime.render([template])}
+              </CustomScopeProvider>
+            </Col>,
+          );
+      }
+      workingRows.push(
+        <Row
+          gutter={[styles?.horizontalGap ?? 10, styles?.verticalGap ?? 10]}
+          key={i}
+          style={{
+            alignItems: "center",
+            marginTop: (styles?.verticalGap ?? 20) / 2,
+            marginBottom: (styles?.verticalGap ?? 20) / 2,
+          }}
+        >
+          {cols}
+        </Row>,
+      );
     }
-    rows.push(
-      <Row
-        gutter={[styles?.horizontalGap ?? 10, styles?.verticalGap ?? 10]}
-        key={i}
-        style={{
-          alignItems: "center",
-          marginTop: (styles?.verticalGap ?? 20) / 2,
-          marginBottom: (styles?.verticalGap ?? 20) / 2,
-        }}
-      >
-        {cols}
-      </Row>,
-    );
-  }
+    return workingRows;
+  }, [
+    namedData,
+    styles?.horizontalGap,
+    styles?.horizontalTileCount,
+    styles?.verticalGap,
+    template,
+  ]);
 
   return <>{rows}</>;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,6 @@ importers:
       chart.js: ^4.4.0
       chartjs-plugin-datalabels: ^2.2.0
       eslint-config-custom: workspace:*
-      jest: 27.5.1
       lodash-es: ^4.17.21
       react-chartjs-2: ^5.2.0
       react-markdown: ^8.0.7
@@ -164,7 +163,6 @@ importers:
       chart.js: 4.4.0
       chartjs-plugin-datalabels: 2.2.0_chart.js@4.4.0
       eslint-config-custom: link:../eslint-config-custom
-      jest: 27.5.1
       lodash-es: 4.17.21
       react-chartjs-2: 5.2.0_chart.js@4.4.0
       react-markdown: 8.0.7_@types+react@18.2.21


### PR DESCRIPTION
## Describe your changes
- Ensures undefined widget keys don't override data context keys in evaluation scope
- Fix invokeApi callbacks firing twice by keeping track of completion state
- Only store states for widgets with explicit IDs to improve performance

### Screenshots [Optional]

## Issue ticket number and link

Closes #207 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
