### PR TITLE
Register custom widget inputs as bindings

### DIFF
--- a/.changeset/dirty-plums-ring.md
+++ b/.changeset/dirty-plums-ring.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+Register custom widget inputs as bindings

--- a/packages/runtime/src/runtime/customWidget.tsx
+++ b/packages/runtime/src/runtime/customWidget.tsx
@@ -1,4 +1,7 @@
-import { CustomScopeProvider } from "@ensembleui/react-framework";
+import {
+  CustomScopeProvider,
+  useRegisterBindings,
+} from "@ensembleui/react-framework";
 import type { CustomWidgetModel } from "@ensembleui/react-framework";
 import React from "react";
 import { EnsembleRuntime } from "./runtime";
@@ -11,8 +14,11 @@ export const createCustomWidget = (
   model: CustomWidgetModel,
 ): React.FC<CustomWidgetProps> => {
   const CustomWidget: React.FC<CustomWidgetProps> = ({ inputs }) => {
+    const { values } = useRegisterBindings<Record<string, unknown>>({
+      ...inputs,
+    });
     return (
-      <CustomScopeProvider value={inputs}>
+      <CustomScopeProvider value={values ?? inputs}>
         {EnsembleRuntime.render([model.body])}
       </CustomScopeProvider>
     );


### PR DESCRIPTION
## Describe your changes
- Use useRegisterBindings to evaluate expressions in inputs before being passed to custom widget

### Screenshots [Optional]

## Issue ticket number and link

Closes #208 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
