### PR TITLE
Added ability to cater nested item-templates

### DIFF
--- a/apps/starter/src/ensemble/screens/usersAndGroups.yaml
+++ b/apps/starter/src/ensemble/screens/usersAndGroups.yaml
@@ -3,9 +3,9 @@ View:
     invokeApi:
       name: getData
       onResponse:
-        executeCode: 
+        executeCode:
           body: |
-            // ensemble.storage.set("arrayOfUsers",response.body.records)
+            ensemble.storage.set("arrayOfUsers",response.body.records)
             console.log("bye")
             const groups = new Set(response.body.records.flatMap(record => record.fields.groups))
             // ensemble.storage.set("arrayOfGroups", Array.from(groups))
@@ -471,11 +471,26 @@ View:
                                               fontWeight: normal
                                               fontSize: 12px
                                               color: "#767676"
-
+              - Column:
+                  item-template:
+                    data: ensemble.storage.get("arrayOfUsers")
+                    name: usr
+                    template:
+                      Row:
+                        gap: 5
+                        children:
+                          - Text:
+                              text: ${usr.fields.name}
+                          - Column:
+                              item-template:
+                                data: usr.fields.groups
+                                name: n1
+                                template:
+                                  Text:
+                                    text: ${n1}
 API:
   getData:
     uri: https://api.airtable.com/v0/app0FnT5yUsW9fjn6/tblWGM6o7vqlTfB8b
     method: GET
     headers:
       Authorization: Bearer patN2XAiLVZQ8Yp3h.2bddb84031b2be89b576f01869dc17c3826e16ae7daa8895f92c05a0799004ab
-

--- a/packages/framework/src/hooks/useTemplateData.ts
+++ b/packages/framework/src/hooks/useTemplateData.ts
@@ -9,9 +9,9 @@ import { evaluate } from "../evaluate";
 import type { Expression } from "../shared/common";
 import { createStorageApi } from "./useEnsembleStorage";
 
-export type TemplateData = object | unknown[];
+export type TemplateData = object | unknown[] | undefined;
 export interface TemplateDataProps {
-  data: Expression<TemplateData>;
+  data?: Expression<TemplateData>;
   name?: string;
 }
 
@@ -40,11 +40,6 @@ export const useTemplateData = ({
             return data;
           }
           try {
-            if (Array.isArray(data)) {
-              return data.map((item) => {
-                return String(item);
-              });
-            }
             return evaluate(screenContext, String(data), {
               ensemble: {
                 storage: createStorageApi(screenContext.storage),

--- a/packages/framework/src/hooks/useTemplateData.ts
+++ b/packages/framework/src/hooks/useTemplateData.ts
@@ -40,6 +40,15 @@ export const useTemplateData = ({
             return data;
           }
           try {
+            if (Array.isArray(data)) {
+              return data.map((item) => {
+                return evaluate(screenContext, String(item), {
+                  ensemble: {
+                    storage: createStorageApi(screenContext.storage),
+                  },
+                });
+              });
+            }
             return evaluate(screenContext, String(data), {
               ensemble: {
                 storage: createStorageApi(screenContext.storage),

--- a/packages/framework/src/hooks/useTemplateData.ts
+++ b/packages/framework/src/hooks/useTemplateData.ts
@@ -42,11 +42,7 @@ export const useTemplateData = ({
           try {
             if (Array.isArray(data)) {
               return data.map((item) => {
-                return evaluate(screenContext, String(item), {
-                  ensemble: {
-                    storage: createStorageApi(screenContext.storage),
-                  },
-                });
+                return String(item);
               });
             }
             return evaluate(screenContext, String(data), {

--- a/packages/runtime/src/widgets/Column.tsx
+++ b/packages/runtime/src/widgets/Column.tsx
@@ -2,30 +2,29 @@ import { useMemo } from "react";
 import { Col } from "antd";
 import { get, indexOf, keys } from "lodash-es";
 import {
-  type CustomScope,
   CustomScopeProvider,
   useRegisterBindings,
   useTemplateData,
-  Expression,
 } from "@ensembleui/react-framework";
+import type { CustomScope } from "@ensembleui/react-framework";
 import { WidgetRegistry } from "../registry";
 import { EnsembleRuntime } from "../runtime";
 import type { FlexboxProps } from "../shared/types";
 import { getColor, getCrossAxis, getMainAxis } from "../shared/styles";
 
 export const Column: React.FC<FlexboxProps> = (props) => {
-  const itemTemplate = props["item-template"];
+  const { "item-template": itemTemplate, ...rest } = props;
   const childrenFirst =
     indexOf(keys(props), "children") < indexOf(keys(props), "item-template");
 
-  const { values, rootRef } = useRegisterBindings({ ...props }, props.id);
+  const { values, rootRef } = useRegisterBindings({ ...rest }, props.id);
   const { namedData } = useTemplateData({
-    data: itemTemplate?.data as Expression<object>,
+    data: itemTemplate?.data,
     name: itemTemplate?.name,
   });
 
   const renderedChildren = useMemo(() => {
-    return props.children ? EnsembleRuntime.render(props?.children) : null;
+    return props.children ? EnsembleRuntime.render(props.children) : null;
   }, [props.children]);
 
   return (
@@ -51,11 +50,12 @@ export const Column: React.FC<FlexboxProps> = (props) => {
         ...(get(props, "styles") as object),
       }}
     >
-      {childrenFirst && renderedChildren}
-      {namedData?.map((n, index) => (
+      {childrenFirst ? renderedChildren : null}
+      {namedData.map((n, index) => (
         <CustomScopeProvider key={index} value={n as CustomScope}>
-          {itemTemplate?.template &&
-            EnsembleRuntime.render([itemTemplate.template])}
+          {itemTemplate?.template
+            ? EnsembleRuntime.render([itemTemplate.template])
+            : null}
         </CustomScopeProvider>
       ))}
       {!childrenFirst && renderedChildren}

--- a/packages/runtime/src/widgets/Row.tsx
+++ b/packages/runtime/src/widgets/Row.tsx
@@ -6,7 +6,6 @@ import {
   CustomScopeProvider,
   useRegisterBindings,
   useTemplateData,
-  Expression,
 } from "@ensembleui/react-framework";
 import { WidgetRegistry } from "../registry";
 import { EnsembleRuntime } from "../runtime";
@@ -14,18 +13,18 @@ import { getColor, getCrossAxis, getMainAxis } from "../shared/styles";
 import type { FlexboxProps } from "../shared/types";
 
 export const Row: React.FC<FlexboxProps> = (props) => {
-  const itemTemplate = props["item-template"];
+  const { "item-template": itemTemplate, ...rest } = props;
   const childrenFirst =
     indexOf(keys(props), "children") < indexOf(keys(props), "item-template");
 
-  const { values, rootRef } = useRegisterBindings({ ...props }, props.id);
+  const { values, rootRef } = useRegisterBindings({ ...rest }, props.id);
   const { namedData } = useTemplateData({
-    data: itemTemplate?.data as Expression<object>,
+    data: itemTemplate?.data,
     name: itemTemplate?.name,
   });
 
   const renderedChildren = useMemo(() => {
-    return props.children ? EnsembleRuntime.render(props?.children) : null;
+    return props.children ? EnsembleRuntime.render(props.children) : null;
   }, [props.children]);
 
   return (
@@ -56,11 +55,12 @@ export const Row: React.FC<FlexboxProps> = (props) => {
         flexGrow: "unset",
       }}
     >
-      {childrenFirst && renderedChildren}
-      {namedData?.map((n, index) => (
+      {childrenFirst ? renderedChildren : null}
+      {namedData.map((n, index) => (
         <CustomScopeProvider key={index} value={n as CustomScope}>
-          {itemTemplate?.template &&
-            EnsembleRuntime.render([itemTemplate.template])}
+          {itemTemplate?.template
+            ? EnsembleRuntime.render([itemTemplate.template])
+            : null}
         </CustomScopeProvider>
       ))}
       {!childrenFirst && renderedChildren}


### PR DESCRIPTION
## Describe your changes
- Added support for one level deep nested item-templates 
### Screenshots [Optional]
```yaml
- Column:
      item-template:
        data: ensemble.storage.get("arrayOfUsers")
        name: usr
        template:
          Row:
            gap: 5
            children:
              - Text:
                  text: ${usr.fields.name}
              - Column:
                  item-template:
                    data: usr.fields.groups
                    name: n1
                    template:
                      Text:
                        text: ${n1}
```
<img width="716" alt="Screenshot 2023-12-08 at 6 40 20 PM" src="https://github.com/EnsembleUI/ensemble-react/assets/62849614/3fa43c68-3af0-4b32-90bf-8fc40480af69">

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
