### PR TITLE
[Hotfix] handle nullable item template in dropdown

### DIFF
--- a/.changeset/olive-cougars-draw.md
+++ b/.changeset/olive-cougars-draw.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+Handle nullable item template in dropdown

--- a/apps/starter/package.json
+++ b/apps/starter/package.json
@@ -32,7 +32,6 @@
   },
   "scripts": {
     "start": "craco start",
-    "dev": "craco start",
     "build": "craco build",
     "test": "craco test --watchAll=false",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## Describe your changes
- Handles nullable item template in dropdown that was creating regression

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
