### PR TITLE
fix: added stickey header and footer in data grid

### DIFF
--- a/.changeset/famous-fans-compare.md
+++ b/.changeset/famous-fans-compare.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+Added feature for enable stickey header and footer in data grid widget

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -49,8 +49,8 @@ View:
                     - label: ADVOCATE
                     - label: ICON
                     - label: MENU
-                  scrollable: true
-                  scrollHeight: 400
+                  scroll:
+                    scrollHeight: 400
                   item-template:
                     data:
                       [

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -49,200 +49,12 @@ View:
                     - label: ADVOCATE
                     - label: ICON
                     - label: MENU
-                  scroll:
-                    scrollHeight: 400
                   item-template:
                     data:
                       [
                         { key: "1", patient: "John", advocate: "Mike Ross" },
                         {
                           key: "2",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "3", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "4",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "5", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "6",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "7", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "8",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "9", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "10",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "11", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "12",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "13", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "14",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "15", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "16",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "17", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "18",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "19", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "20",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "21", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "22",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "23", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "24",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "25", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "26",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "27", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "28",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "29", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "30",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "31", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "32",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "33", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "34",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "35", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "36",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "37", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "38",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "39", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "40",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "41", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "42",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "43", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "44",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "45", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "46",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "47", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "48",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "49", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "50",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "51", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "52",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "53", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "54",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "55", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "56",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "57", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "58",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "59", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "60",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "61", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "62",
-                          patient: "Reuben",
-                          advocate: "Harvey Dent",
-                        },
-                        { key: "63", patient: "John", advocate: "Mike Ross" },
-                        {
-                          key: "64",
                           patient: "Reuben",
                           advocate: "Harvey Dent",
                         },
@@ -287,6 +99,39 @@ View:
                               widget:
                                 Icon:
                                   name: QuestionMark
+
+        - Card:
+            styles:
+              maxWidth: unset
+              width: unset
+              gap: 10px
+            children:
+              - Text:
+                  styles:
+                    names: heading-3
+                  text: DataGrid
+              - DataGrid:
+                  styles:
+                    headerStyle:
+                      backgroundColor: "white"
+                      fontSize: "12px"
+                      textColor: "#747184"
+                      hasDivider: true
+                      borderBottom: false
+                  hidePagination: true
+                  DataColumns:
+                    - label: Number
+                  scroll:
+                    scrollHeight: 200
+                  item-template:
+                    data: ${getDummyNumbers.body}
+                    name: dummyData
+                    template:
+                      DataRow:
+                        children:
+                          - Text:
+                              id: ${dummyData}
+                              text: ${dummyData}
         - Card:
             styles:
               maxWidth: unset
@@ -541,6 +386,9 @@ View:
                         id: onChangeDemo
 
 API:
+  getDummyProducts:
+    method: GET
+    uri: https://dummyjson.com/products
   getDummyNumbers:
     method: GET
     uri: https://mocki.io/v1/c1f19d68-e6c8-4ae3-848d-d99e588cf224

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -49,11 +49,203 @@ View:
                     - label: ADVOCATE
                     - label: ICON
                     - label: MENU
+                  scrollable: true
+                  scrollHeight: 400
                   item-template:
                     data:
                       [
                         { key: "1", patient: "John", advocate: "Mike Ross" },
-                        { key: "2", patient: "Reuben", advocate: "Harvey Dent" },
+                        {
+                          key: "2",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "3", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "4",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "5", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "6",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "7", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "8",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "9", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "10",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "11", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "12",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "13", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "14",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "15", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "16",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "17", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "18",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "19", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "20",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "21", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "22",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "23", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "24",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "25", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "26",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "27", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "28",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "29", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "30",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "31", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "32",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "33", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "34",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "35", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "36",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "37", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "38",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "39", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "40",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "41", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "42",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "43", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "44",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "45", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "46",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "47", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "48",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "49", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "50",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "51", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "52",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "53", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "54",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "55", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "56",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "57", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "58",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "59", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "60",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "61", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "62",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
+                        { key: "63", patient: "John", advocate: "Mike Ross" },
+                        {
+                          key: "64",
+                          patient: "Reuben",
+                          advocate: "Harvey Dent",
+                        },
                       ]
                     name: dummyData
                     key: ${dummyData.key}
@@ -82,7 +274,11 @@ View:
                                 - label: Location
                                   value: location
                               item-template:
-                                data: [{ name: "hello", value: 11 }, { name: "buyyy", value: 22 }]
+                                data:
+                                  [
+                                    { name: "hello", value: 11 },
+                                    { name: "buyyy", value: 22 },
+                                  ]
                                 name: product
                                 value: ${product.value}
                                 template:
@@ -90,7 +286,7 @@ View:
                                     text: ${product.name}
                               widget:
                                 Icon:
-                                  name: QuestionMark                              
+                                  name: QuestionMark
         - Card:
             styles:
               maxWidth: unset
@@ -223,7 +419,7 @@ View:
                                   ]
                               }
                           }
-                
+
         - Card:
             styles:
               maxWidth: unset

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -55,6 +55,10 @@ export interface DataGridRowTemplate {
   };
 }
 
+export interface DataGridScrollable {
+  scrollHeight: string;
+}
+
 export type GridProps = {
   allowSelection?: boolean;
   onRowsSelected?: EnsembleAction;
@@ -68,6 +72,7 @@ export type GridProps = {
     template: DataGridRowTemplate;
   };
   hidePagination?: boolean;
+  scroll?: DataGridScrollable;
 } & EnsembleWidgetProps<DataGridStyles>;
 
 export interface DataGridRowTemplate {
@@ -172,7 +177,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
             : undefined
         }
         scroll={
-          values?.scrollable ? { y: values.scrollHeight || 150 } : undefined
+          values?.scroll ? { y: values.scroll.scrollHeight || 150 } : undefined
         }
         style={{
           width: "100%",

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -59,6 +59,8 @@ export type GridProps = {
   allowSelection?: boolean;
   onRowsSelected?: EnsembleAction;
   DataColumns: DataColumn[];
+  scrollable?: boolean;
+  scrollHeight?: number;
   "item-template": {
     data: Expression<object>;
     name: string;
@@ -142,6 +144,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
         onRow={(record, recordIndex) => {
           return { onClick: () => onTapActionCallback(record, recordIndex) };
         }}
+        pagination={values?.hidePagination ? false : undefined}
         ref={rootRef}
         rowKey={(data: unknown) => {
           const identifier: string = evaluate(
@@ -168,6 +171,9 @@ export const DataGrid: React.FC<GridProps> = (props) => {
               }
             : undefined
         }
+        scroll={
+          values?.scrollable ? { y: values.scrollHeight || 150 } : undefined
+        }
         style={{
           width: "100%",
           ...values?.styles,
@@ -175,7 +181,6 @@ export const DataGrid: React.FC<GridProps> = (props) => {
             ? { display: "none" }
             : undefined),
         }}
-        pagination={values?.hidePagination ? false : undefined}
       >
         {DataColumns?.map((col, index) => {
           return (

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -56,15 +56,14 @@ export interface DataGridRowTemplate {
 }
 
 export interface DataGridScrollable {
-  scrollHeight: string;
+  scrollHeight?: string;
+  scrollWidth?: string;
 }
 
 export type GridProps = {
   allowSelection?: boolean;
   onRowsSelected?: EnsembleAction;
   DataColumns: DataColumn[];
-  scrollable?: boolean;
-  scrollHeight?: number;
   "item-template": {
     data: Expression<object>;
     name: string;
@@ -177,7 +176,12 @@ export const DataGrid: React.FC<GridProps> = (props) => {
             : undefined
         }
         scroll={
-          values?.scroll ? { y: values.scroll.scrollHeight || 150 } : undefined
+          values?.scroll
+            ? {
+                y: values.scroll.scrollHeight || 150,
+                x: values.scroll.scrollWidth || 0,
+              }
+            : undefined
         }
         style={{
           width: "100%",


### PR DESCRIPTION
## Describe your changes
Added feature for enable stickey header and footer in data grid widget

### Screenshots [Optional]

## Issue ticket number and link

Closes #
closes #364 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
