### PR TITLE
added stop event propagation

### DIFF
--- a/.changeset/afraid-days-sniff.md
+++ b/.changeset/afraid-days-sniff.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+added stop event propogation in button onTap action

--- a/apps/kitchen-sink/src/ensemble/screens/layouts.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/layouts.yaml
@@ -66,11 +66,21 @@ View:
                 console.log('Hello', data, collapseWidget)
         - Collapsible:
             expandIconPosition: "end"
+            value: "1"
             items:
               - key: "1"
                 label:
-                  Text:
-                    text: Here is my label 1
+                  Column:
+                    children:
+                      - Text:
+                          text: Here is my label 1
+                      - Button:
+                          label: this is button
+                          onTap:
+                            showDialog:
+                              widget:
+                                Text:
+                                  text: name
                 children: hiii
               - key: "2"
                 label: Here is my label 2
@@ -79,7 +89,7 @@ View:
                     text: Here is my value 2
             onCollapse:
               executeCode: |
-                console.log('Hello', data)                            
+                console.log('Hello', data)
 
   footer:
     children:

--- a/packages/runtime/src/widgets/Button.tsx
+++ b/packages/runtime/src/widgets/Button.tsx
@@ -1,7 +1,7 @@
 import type { EnsembleAction, Expression } from "@ensembleui/react-framework";
 import { useRegisterBindings } from "@ensembleui/react-framework";
 import { Button as AntButton, Form as AntForm } from "antd";
-import { useCallback, useMemo } from "react";
+import { type MouseEvent, useCallback, useMemo } from "react";
 import { WidgetRegistry } from "../registry";
 import type { EnsembleWidgetProps, IconProps } from "../shared/types";
 import { useEnsembleAction } from "../runtime/hooks/useEnsembleAction";
@@ -22,12 +22,16 @@ export type ButtonProps = {
 export const Button: React.FC<ButtonProps> = ({ id, onTap, ...rest }) => {
   const { values, rootRef } = useRegisterBindings(rest, id);
   const action = useEnsembleAction(onTap);
-  const onClickCallback = useCallback(() => {
-    if (!action) {
-      return;
-    }
-    action.callback();
-  }, [action]);
+  const onClickCallback = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      if (!action) {
+        return;
+      }
+      action.callback();
+    },
+    [action],
+  );
 
   const ButtonComponent = useMemo(() => {
     return (


### PR DESCRIPTION
## Describe your changes
Added stop event propagation in button onTap action

### Screenshots [Optional]

## Issue ticket number and link
When we put the button on the collapsible header and when we click on the button, it execute the callback of the button, but it also collapse the collapsible item. so to prevent that behaviour, I added stop event propagation in button callback

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
