### PR TITLE
expose useEnsembleAction hook for outer world

### DIFF
--- a/.changeset/chilly-dragons-kneel.md
+++ b/.changeset/chilly-dragons-kneel.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+expose useEnsembleAction hook for outer world

--- a/packages/runtime/src/index.tsx
+++ b/packages/runtime/src/index.tsx
@@ -1,4 +1,5 @@
 export * from "./EnsembleApp";
 export * from "./registry";
+export * from "./runtime/hooks";
 // component exports
 export * from "./widgets";

--- a/packages/runtime/src/runtime/hooks/index.ts
+++ b/packages/runtime/src/runtime/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useEnsembleAction } from "./useEnsembleAction";


### PR DESCRIPTION
## Issue
`useEnsembleAction` hook does not become the part of build. Need to use it to implement action in a custom widget implementation on customer app.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
