### PR TITLE
fix: added execution support of onResponse and onError in API block d…

### DIFF
--- a/.changeset/tricky-buckets-search.md
+++ b/.changeset/tricky-buckets-search.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+added support to return the API response in ensemble.invokeAPI

--- a/apps/kitchen-sink/src/ensemble/screens/actions.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/actions.yaml
@@ -89,7 +89,7 @@ View:
                           age: 30,
                         };
                         ensemble.navigateScreen({
-                          name: 'home', 
+                          name: 'home',
                           inputs: payload
                         });
         - Card:
@@ -348,6 +348,22 @@ View:
                         url: 'https://google.com',
                         openNewTab: true
                       })
+              - Card:
+                  styles:
+                    maxWidth: unset
+                    width: unset
+                  children:
+                    - Text:
+                        styles:
+                          names: heading-3
+                        text: Trigger API using ensemble.invokeApi
+                    - Button:
+                        label: Trigger API
+                        onTap:
+                          executeCode: |
+                            ensemble.invokeAPI('getDummyProducts').then((res) => {
+                              console.log(res)
+                            })
 
 API:
   getDummyProducts:

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -809,9 +809,9 @@ API:
   getDummyProducts:
     method: GET
     uri: https://dummyjson.com/products
-    onResponse:
-      executeCode: |
-        console.log('product fetched')
   getDummyNumbers:
     method: GET
     uri: https://mocki.io/v1/c1f19d68-e6c8-4ae3-848d-d99e588cf224
+    onResponse:
+      executeCode: |
+        console.log('dummy number fetched')

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -363,7 +363,7 @@ View:
                                     }
                                   }
                                 }
-                              }  
+                              }
                           }
                     - Chart:
                         id: myDoughnutChart
@@ -809,6 +809,9 @@ API:
   getDummyProducts:
     method: GET
     uri: https://dummyjson.com/products
+    onResponse:
+      executeCode: |
+        console.log('product fetched')
   getDummyNumbers:
     method: GET
     uri: https://mocki.io/v1/c1f19d68-e6c8-4ae3-848d-d99e588cf224

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -156,14 +156,16 @@ export const useExecuteCode: EnsembleActionHook<
                 invokeAPI: async (
                   apiName: string,
                   apiInputs?: Record<string, unknown>,
-                ) =>
-                  invokeAPI(
+                ) => {
+                  const apiRes = await invokeAPI(
                     screen,
                     screenData,
                     apiName,
                     apiInputs,
                     customScope,
-                  ),
+                  );
+                  return apiRes;
+                },
                 navigateBack: (): void => navigateBack(navigate),
                 navigateExternalScreen: (url: NavigateExternalScreen) =>
                   navigateExternalScreen(url),

--- a/packages/runtime/src/runtime/invokeApi.tsx
+++ b/packages/runtime/src/runtime/invokeApi.tsx
@@ -23,4 +23,6 @@ export const invokeAPI = async (
   );
   const res = await DataFetcher.fetch(api, evaluatedInputs);
   screenData.setData(api.name, res);
+
+  return res;
 };


### PR DESCRIPTION
Added support for execution of onResponse and onError block of API block definition in sequential with invokeAPI's onResponse and onError

## Describe your changes

### Screenshots [Optional]

## Issue ticket number and link

Closes #465 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
