### PR TITLE
fix: only render dropdown after options render

### DIFF
--- a/.changeset/big-ghosts-fold.md
+++ b/.changeset/big-ghosts-fold.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+fix: dropdown render after options loaded

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -859,13 +859,43 @@ View:
               - Button:
                   label: Next
                   onTap:
-                    executeCode:  |
+                    executeCode: |
                       workflowStepper.handleNext();
               - Button:
                   label: Prev
                   onTap:
-                    executeCode:  |
+                    executeCode: |
                       workflowStepper.handleBack();
+
+        - Card:
+            styles:
+              maxWidth: unset
+              width: unset
+              gap: 10px
+            children:
+              - Text:
+                  styles:
+                    names: heading-3
+                  text: Dynamic options Dropdown
+              - Button:
+                  label: load options
+                  onTap:
+                    invokeApi:
+                      name: "getDummyProducts"
+                      onResponse:
+                        executeCode: |
+                          ensemble.storage.set('dynamicDropdownOptions', response.body.products)
+              - Dropdown:
+                  label: With the label widget
+                  hintText: Hint Text
+                  value: 15
+                  item-template:
+                    data: ${ensemble.storage.get('dynamicDropdownOptions')}
+                    name: product
+                    value: ${product.id}
+                    template:
+                      Text:
+                        text: ${product.title}
 API:
   getDummyProducts:
     method: GET

--- a/packages/runtime/src/widgets/Form/Dropdown.tsx
+++ b/packages/runtime/src/widgets/Form/Dropdown.tsx
@@ -152,6 +152,10 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
 
   const { backgroundColor: _, ...formItemStyles } = values?.styles ?? {};
 
+  if (isEmpty(options)) {
+    return null;
+  }
+
   return (
     <>
       <style>{`

--- a/packages/runtime/src/widgets/Form/Dropdown.tsx
+++ b/packages/runtime/src/widgets/Form/Dropdown.tsx
@@ -13,7 +13,7 @@ import type {
   EnsembleAction,
   Expression,
 } from "@ensembleui/react-framework";
-import { get, isEmpty, isObject, isString } from "lodash-es";
+import { get, isEmpty, isNull, isObject, isString } from "lodash-es";
 import { WidgetRegistry } from "../../registry";
 import type {
   EnsembleWidgetProps,
@@ -83,7 +83,7 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
   });
 
   const options = useMemo(() => {
-    const dropdownOptions = [];
+    let dropdownOptions = null;
     if (values?.items) {
       const tempOptions = values.items.map((item) => {
         if (item.type === "group") {
@@ -119,7 +119,7 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
         );
       });
 
-      dropdownOptions.push(...tempOptions);
+      dropdownOptions = tempOptions;
     }
 
     if (isObject(itemTemplate) && !isEmpty(namedData)) {
@@ -144,7 +144,7 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
         );
       });
 
-      dropdownOptions.push(...tempOptions);
+      dropdownOptions = [...(dropdownOptions || []), ...tempOptions];
     }
 
     return dropdownOptions;
@@ -152,7 +152,7 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
 
   const { backgroundColor: _, ...formItemStyles } = values?.styles ?? {};
 
-  if (isEmpty(options)) {
+  if (isNull(options)) {
     return null;
   }
 


### PR DESCRIPTION
## Describe your changes
to fix delay in initial loaded value with the right option, only allow dropdown render once options are loaded

### Screenshots [Optional]

## Issue ticket number and link

Closes #470 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
