### PR TITLE
fix: added id attribute on formItem widget

### DIFF
--- a/packages/framework/src/evaluate/evaluate.ts
+++ b/packages/framework/src/evaluate/evaluate.ts
@@ -29,6 +29,7 @@ export const buildEvaluateFn = (
     ...Object.keys(invokableObj),
     addGlobalBlock(formatJs(js), globalBlock),
   );
+
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return () => jsFunc(...Object.values(invokableObj));
 };
@@ -74,7 +75,7 @@ const addGlobalBlock = (js: string, globalBlock?: string): string =>
  * @param context- any additional context needed for the script
  * @returns the result of the evaluated expression/script
  */
-export const evaluate = <T = unknown>(
+export const evaluate = <T = unknown,>(
   screen: Partial<ScreenContextDefinition>,
   js?: string,
   context?: Record<string, unknown>,

--- a/packages/runtime/src/widgets/Form/FormItem.tsx
+++ b/packages/runtime/src/widgets/Form/FormItem.tsx
@@ -1,9 +1,9 @@
 import type { FormItemProps } from "antd";
 import { Form as AntForm } from "antd";
-import type { FormInputProps } from "./types";
 import { isString } from "lodash-es";
-import { EnsembleRuntime } from "../../runtime";
 import { unwrapWidget } from "@ensembleui/react-framework";
+import { EnsembleRuntime } from "../../runtime";
+import type { FormInputProps } from "./types";
 
 export type EnsembleFormItemProps<T> = FormItemProps & {
   values?: FormInputProps<T>;
@@ -17,9 +17,11 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
 ) => {
   const { values, ...rest } = props;
   const { backgroundColor: _, ...formItemStyles } = values?.styles ?? {};
+
   return (
     <AntForm.Item
       className={values?.styles?.names}
+      id={values?.id ?? values?.label}
       initialValue={values?.value}
       label={
         values?.label ? (
@@ -36,7 +38,6 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
           </label>
         ) : null
       }
-      name={values?.id ?? values?.label}
       rules={[{ required: Boolean(values?.required) }]}
       style={{
         margin: "0px",


### PR DESCRIPTION
## Describe your changes
Added support of id attribute on formItem widget to set form elements value through setValue

### Screenshots [Optional]

## Issue ticket number and link

Closes #485 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
