### PR TITLE
Add force option to useRegisterBindings hook

### DIFF
--- a/.changeset/great-mails-complain.md
+++ b/.changeset/great-mails-complain.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-framework": patch
+---
+
+add force option in useRegisterBindings hook

--- a/packages/framework/src/hooks/useRegisterBindings.ts
+++ b/packages/framework/src/hooks/useRegisterBindings.ts
@@ -19,6 +19,9 @@ export const useRegisterBindings = <T extends { [key: string]: unknown }>(
   values: T,
   id?: string,
   methods?: InvokableMethods,
+  options?: {
+    forceRerender?: boolean;
+  },
 ): RegisterBindingsResult<T> => {
   const testId = get(values, ["testId"]);
 
@@ -70,6 +73,15 @@ export const useRegisterBindings = <T extends { [key: string]: unknown }>(
     widgetState?.invokable.methods,
     id,
   ]);
+
+  useEffect(() => {
+    if (options?.forceRerender) {
+      setWidgetState({
+        values: newValues,
+        invokable: { id: resolvedWidgetId, methods },
+      });
+    }
+  }, [options?.forceRerender]);
 
   const updatedValues = widgetState?.values ?? newValues;
   const htmlAttributes = get(updatedValues, "htmlAttributes") as {

--- a/packages/framework/src/hooks/useRegisterBindings.ts
+++ b/packages/framework/src/hooks/useRegisterBindings.ts
@@ -20,7 +20,7 @@ export const useRegisterBindings = <T extends { [key: string]: unknown }>(
   id?: string,
   methods?: InvokableMethods,
   options?: {
-    forceRerender?: boolean;
+    forceState?: boolean;
   },
 ): RegisterBindingsResult<T> => {
   const testId = get(values, ["testId"]);
@@ -75,13 +75,13 @@ export const useRegisterBindings = <T extends { [key: string]: unknown }>(
   ]);
 
   useEffect(() => {
-    if (options?.forceRerender) {
+    if (options?.forceState === true) {
       setWidgetState({
         values: newValues,
         invokable: { id: resolvedWidgetId, methods },
       });
     }
-  }, [options?.forceRerender]);
+  }, [options?.forceState]);
 
   const updatedValues = widgetState?.values ?? newValues;
   const htmlAttributes = get(updatedValues, "htmlAttributes") as {


### PR DESCRIPTION
## Describe your changes
Add force option in useRegisterBindings hook

### Problem
React component using useRegisterBindings hook was not being re-rendered properly when re-mounted with same values. 

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
