### PR TITLE
fix: added support for onSort action handler in datagrid

### DIFF
--- a/.changeset/tender-students-doubt.md
+++ b/.changeset/tender-students-doubt.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+Added support for onSort action handler in datagrid

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -261,6 +261,55 @@ View:
                           template:
                             Text:
                               text: ${value}
+
+        - Card:
+            styles:
+              maxWidth: unset
+              width: unset
+              gap: 10px
+            children:
+              - Text:
+                  styles:
+                    names: heading-3
+                  text: DataGrid with sort example
+              - DataGrid:
+                  id: "myDataGridExample3"
+                  styles:
+                    headerStyle:
+                      backgroundColor: "white"
+                      fontSize: "12px"
+                      textColor: "#747184"
+                      hasDivider: true
+                      borderBottom: false
+                  DataColumns:
+                    - label: id
+                      sort:
+                        compareFn: |
+                          a.dummyData.id - b.dummyData.id
+                    - label: title
+                    - label: description
+                  hidePagination: true
+                  onSort:
+                    executeCode: |
+                      // TODO: here this condition is required because sort return undefined when sort on any perticular column has been removed.
+                      if (column_title && sort_order) {
+                        ensemble.invokeAPI('getMockProducts', {'sortBy': column_title, 'sortOrder': sort_order === 'descend' ? 'desc' : 'asc'}).then((res) => {
+                          console.log(res)
+                        })
+                      }
+
+                  item-template:
+                    data: ${ensemble.storage.get('dummyProducts')}
+                    name: dummyData
+                    key: ${dummyData.key}
+                    template:
+                      DataRow:
+                        item-template:
+                          data: ${Object.values(dummyData)}
+                          name: value
+                          template:
+                            Text:
+                              text: ${value}
         - Card:
             styles:
               maxWidth: unset
@@ -942,6 +991,12 @@ API:
     uri: https://dummyjson.com/products?skip=${skip}&limit=10
     inputs:
       - skip
+  getMockProducts:
+    method: GET
+    uri: https://661e111b98427bbbef034208.mockapi.io/products?sortBy=${sortBy}&order=${sortOrder}&limit=10
+    inputs:
+      - sortBy
+      - sortOrder
   getDummyNumbers:
     method: GET
     uri: https://mocki.io/v1/c1f19d68-e6c8-4ae3-848d-d99e588cf224

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -292,8 +292,8 @@ View:
                   onSort:
                     executeCode: |
                       // TODO: here this condition is required because sort return undefined when sort on any perticular column has been removed.
-                      if (column_title && sort_order) {
-                        ensemble.invokeAPI('getMockProducts', {'sortBy': column_title, 'sortOrder': sort_order === 'descend' ? 'desc' : 'asc'}).then((res) => {
+                      if (columnTitle && sortOrder) {
+                        ensemble.invokeAPI('getMockProducts', {'sortBy': columnTitle, 'sortOrder': sortOrder === 'descend' ? 'desc' : 'asc'}).then((res) => {
                           console.log(res)
                         })
                       }

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -319,10 +319,6 @@ export const DataGrid: React.FC<GridProps> = (props) => {
       case "sort":
         onSortActionCallback(sorter);
         break;
-
-      default:
-        console.log("data grid changes");
-        break;
     }
   };
 

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -304,9 +304,10 @@ export const DataGrid: React.FC<GridProps> = (props) => {
   const onSortActionCallback = useCallback(
     (sorter: SorterResult<unknown>) => {
       if (onSortAction) {
+        console.log({ sorter });
         onSortAction.callback({
-          sort_order: sorter.order,
-          column_title: sorter.column?.title,
+          sortOrder: sorter.order,
+          columnTitle: sorter.column?.title,
         });
       }
     },

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -1,4 +1,5 @@
 import { Table, type TableProps } from "antd";
+import type { SorterResult } from "antd/es/table/interface";
 import {
   Resizable,
   type ResizableProps,
@@ -301,9 +302,12 @@ export const DataGrid: React.FC<GridProps> = (props) => {
   const onSortAction = useEnsembleAction(onSort);
   // page change action
   const onSortActionCallback = useCallback(
-    (sorter: Partial<TableProps["onChange"]>) => {
+    (sorter: SorterResult<unknown>) => {
       if (onSortAction) {
-        onSortAction.callback({ sorter });
+        onSortAction.callback({
+          sort_order: sorter.order,
+          column_title: sorter.column?.title,
+        });
       }
     },
     [onSortAction],
@@ -317,7 +321,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
   ) => {
     switch (extra.action) {
       case "sort":
-        onSortActionCallback(sorter);
+        onSortActionCallback(sorter as SorterResult<unknown>);
         break;
 
       default:

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -319,6 +319,9 @@ export const DataGrid: React.FC<GridProps> = (props) => {
       case "sort":
         onSortActionCallback(sorter);
         break;
+
+      default:
+        break;
     }
   };
 

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -1,4 +1,4 @@
-import { Table } from "antd";
+import { Table, type TableProps } from "antd";
 import {
   Resizable,
   type ResizableProps,
@@ -85,6 +85,7 @@ export type GridProps = {
   scroll?: DataGridScrollable;
   onScrollEnd?: EnsembleAction;
   onPageChange?: EnsembleAction;
+  onSort?: EnsembleAction;
   pageSize?: number;
 } & EnsembleWidgetProps<DataGridStyles>;
 
@@ -140,6 +141,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
     "item-template": itemTemplate,
     onScrollEnd,
     onPageChange,
+    onSort,
     ...rest
   } = props;
   const [selectionType, setSelectionType] = useState<"checkbox" | "radio">(
@@ -296,12 +298,41 @@ export const DataGrid: React.FC<GridProps> = (props) => {
     return { onChange: handlePageChange, pageSize: values?.pageSize };
   }, [values?.hidePagination, values?.pageSize]);
 
+  const onSortAction = useEnsembleAction(onSort);
+  // page change action
+  const onSortActionCallback = useCallback(
+    (sorter: Partial<TableProps["onChange"]>) => {
+      if (onSortAction) {
+        onSortAction.callback({ sorter });
+      }
+    },
+    [onSortAction],
+  );
+
+  const onChange: TableProps["onChange"] = (
+    pagination,
+    filters,
+    sorter,
+    extra,
+  ) => {
+    switch (extra.action) {
+      case "sort":
+        onSortActionCallback(sorter);
+        break;
+
+      default:
+        console.log("data grid changes");
+        break;
+    }
+  };
+
   return (
     <div id={resolvedWidgetId} ref={containerRef}>
       <Table
         components={components}
         dataSource={namedData}
         key={resolvedWidgetId}
+        onChange={onChange}
         onRow={(record, recordIndex) => {
           return { onClick: () => onTapActionCallback(record, recordIndex) };
         }}

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -304,7 +304,6 @@ export const DataGrid: React.FC<GridProps> = (props) => {
   const onSortActionCallback = useCallback(
     (sorter: SorterResult<unknown>) => {
       if (onSortAction) {
-        console.log({ sorter });
         onSortAction.callback({
           sortOrder: sorter.order,
           columnTitle: sorter.column?.title,

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -304,13 +304,20 @@ export const DataGrid: React.FC<GridProps> = (props) => {
   const onSortActionCallback = useCallback(
     (sorter: SorterResult<unknown>) => {
       if (onSortAction) {
+        const namedDataObject = namedData?.[0] as { [key: string]: unknown };
+        const dataObject = namedDataObject[sorter.field as string] as {
+          [key: string]: unknown;
+        };
+        const dataObjectKeys = Object.keys(dataObject);
+
         onSortAction.callback({
           sortOrder: sorter.order,
           columnTitle: sorter.column?.title,
+          dataKey: dataObjectKeys[sorter.columnKey as number],
         });
       }
     },
-    [onSortAction],
+    [onSortAction, namedData],
   );
 
   const onChange: TableProps["onChange"] = (


### PR DESCRIPTION
## Describe your changes
Added support for onSort action handler in datagrid widget

### Screenshots [Optional]

## Issue ticket number and link

Closes #513 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
