### PR TITLE
fix: added condition to disable free text entry

### DIFF
--- a/.changeset/poor-numbers-buy.md
+++ b/.changeset/poor-numbers-buy.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+Add functionality to disable create new options in multiselect

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -99,7 +99,7 @@ View:
                         labelKey: firstName
                         valueKey: email
                         items: ${ensemble.storage.get('dummyData')}
-                        mode: "multiple"
+                        allowCreateOptions: false
                         onItemSelect:
                           executeCode: |
                             console.log('selected');

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -99,6 +99,7 @@ View:
                         labelKey: firstName
                         valueKey: email
                         items: ${ensemble.storage.get('dummyData')}
+                        mode: "multiple"
                         onItemSelect:
                           executeCode: |
                             console.log('selected');

--- a/packages/runtime/src/widgets/Form/MultiSelect.tsx
+++ b/packages/runtime/src/widgets/Form/MultiSelect.tsx
@@ -40,7 +40,7 @@ export type MultiSelectProps = {
   items?: Expression<SelectOption[]>;
   onItemSelect?: EnsembleAction;
   hintStyle?: EnsembleWidgetStyles;
-  mode?: "multiple" | "tags";
+  allowCreateOptions?: boolean;
 } & EnsembleWidgetProps<MultiSelectStyles> &
   FormInputProps<string[]>;
 
@@ -132,7 +132,7 @@ const MultiSelect: React.FC<MultiSelectProps> = (props) => {
       option.label.toString().toLowerCase().startsWith(value.toLowerCase()),
     );
 
-    if (isOptionExist || values?.mode !== "tags") setNewOption("");
+    if (isOptionExist || !values?.allowCreateOptions) setNewOption("");
     else {
       setNewOption(value);
     }
@@ -260,7 +260,7 @@ const MultiSelect: React.FC<MultiSelectProps> = (props) => {
                 ?.startsWith(input.toLowerCase()) || false
             }
             id={values?.id}
-            mode={values?.mode || "tags"}
+            mode={values?.allowCreateOptions ? "tags" : "multiple"}
             notFoundContent="No Results"
             onChange={handleChange}
             onSearch={handleSearch}

--- a/packages/runtime/src/widgets/Form/MultiSelect.tsx
+++ b/packages/runtime/src/widgets/Form/MultiSelect.tsx
@@ -40,6 +40,7 @@ export type MultiSelectProps = {
   items?: Expression<SelectOption[]>;
   onItemSelect?: EnsembleAction;
   hintStyle?: EnsembleWidgetStyles;
+  mode?: "multiple" | "tags";
 } & EnsembleWidgetProps<MultiSelectStyles> &
   FormInputProps<string[]>;
 
@@ -127,12 +128,11 @@ const MultiSelect: React.FC<MultiSelectProps> = (props) => {
   };
 
   const handleSearch = (value: string): void => {
-    if (
-      values?.options.some((option) =>
-        option.label.toString().toLowerCase().startsWith(value.toLowerCase()),
-      )
-    )
-      setNewOption("");
+    const isOptionExist = values?.options.some((option) =>
+      option.label.toString().toLowerCase().startsWith(value.toLowerCase()),
+    );
+
+    if (isOptionExist || values?.mode !== "tags") setNewOption("");
     else {
       setNewOption(value);
     }
@@ -260,7 +260,7 @@ const MultiSelect: React.FC<MultiSelectProps> = (props) => {
                 ?.startsWith(input.toLowerCase()) || false
             }
             id={values?.id}
-            mode="tags"
+            mode={values?.mode || "tags"}
             notFoundContent="No Results"
             onChange={handleChange}
             onSearch={handleSearch}


### PR DESCRIPTION
## Describe your changes
Added condition to disable free text entry in multiselect

### Screenshots [Optional]

## Issue ticket number and link

Closes #518 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
