### PR TITLE
Fix Progress widget when filledPercentage is 0

### DIFF
--- a/.changeset/kind-buses-dream.md
+++ b/.changeset/kind-buses-dream.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+show empty progress bar when filledPercentage is 0

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -465,14 +465,13 @@ View:
                     backgroundColor: lime
               - Progress:
                   display: linear
-                  filledPercentage: 75
                   styles:
                     color: ${colors.primary['600']}
                     thickness: 4
                     backgroundColor: ${colors.light['300']}
               - Progress:
                   display: linear
-                  filledPercentage: 33
+                  filledPercentage: 0
                   styles:
                     color: ${colors.primary['600']}
                     thickness: 4

--- a/packages/runtime/src/widgets/Progress.tsx
+++ b/packages/runtime/src/widgets/Progress.tsx
@@ -35,7 +35,6 @@ const Progress: React.FC<ProgressProps> = (props) => {
   // Calculate the percentage based on the countdown value
   const [percent, setPercent] = useState(countdown ? 0 : -1);
   const { id, values } = useRegisterBindings({ ...props }, props.id);
-  const filledPercentage = values?.filledPercentage || 40;
 
   useEffect(() => {
     // If countdown is present and greater than 0, calculate the target percent for animation
@@ -155,7 +154,7 @@ const Progress: React.FC<ProgressProps> = (props) => {
       </div>
     );
   }
-  if (isLinear && filledPercentage) {
+  if (isLinear && values?.filledPercentage !== undefined) {
     return (
       <div style={{ margin: values?.styles?.margin }}>
         <div className={`${id} loader-static`} />
@@ -177,7 +176,7 @@ const Progress: React.FC<ProgressProps> = (props) => {
 			}
 			.${id}.loader-static::after {
 			  content: '';
-			  width: ${filledPercentage}%;
+			  width: ${values?.filledPercentage}%;
 			  height: 100%;
 			  background: ${values?.styles?.color ? values?.styles.color : "#1890ff"};
 			  position: absolute;


### PR DESCRIPTION
## Describe your changes
Setting `filledPercentage` as 0 was triggering the default 40 value.

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
