### PR TITLE
fix: remove evaluate from ensemble.invokeAPI

### DIFF
--- a/packages/runtime/src/runtime/hooks/__tests__/useExecuteCode.test.tsx
+++ b/packages/runtime/src/runtime/hooks/__tests__/useExecuteCode.test.tsx
@@ -26,6 +26,14 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
       id: "test",
       name: "test",
       body: { name: "Widget", properties: {} },
+      apis: [
+        {
+          name: "getDummyProductsByPaginate",
+          method: "GET",
+          uri: "https://dummyjson.com/products?skip=${skip}&limit=${limit}",
+          inputs: ["skip", "limit"],
+        },
+      ],
     }}
   >
     {children}
@@ -75,6 +83,31 @@ test("can be invoked multiple times", () => {
     execResult2 = result.current?.callback();
   });
   expect(execResult2).toBe(2);
+});
+
+test("call ensemble.invokeAPI", async () => {
+  const apiConfig = {
+    limit: 15,
+    skip: 10,
+  };
+
+  const { result } = renderHook(
+    () =>
+      useExecuteCode(
+        "ensemble.invokeAPI('getDummyProductsByPaginate', apiConfig).then((res) => res.body.products.length)",
+        { context: { apiConfig } },
+      ),
+    {
+      wrapper,
+    },
+  );
+
+  let execResult;
+  await act(async () => {
+    execResult = await result.current?.callback();
+  });
+
+  expect(execResult).toBe(apiConfig.limit);
 });
 
 test.todo("populates application invokables");

--- a/packages/runtime/src/runtime/hooks/__tests__/useExecuteCode.test.tsx
+++ b/packages/runtime/src/runtime/hooks/__tests__/useExecuteCode.test.tsx
@@ -30,6 +30,7 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
         {
           name: "getDummyProductsByPaginate",
           method: "GET",
+          // eslint-disable-next-line no-template-curly-in-string
           uri: "https://dummyjson.com/products?skip=${skip}&limit=${limit}",
           inputs: ["skip", "limit"],
         },

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -168,12 +168,6 @@ export const useExecuteCode: EnsembleActionHook<
                     screenData,
                     apiName,
                     apiInputs,
-                    {
-                      ...customScope,
-                      ensemble: {
-                        env: appContext?.env,
-                      },
-                    },
                   );
                   return apiRes;
                 },

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -164,7 +164,6 @@ export const useExecuteCode: EnsembleActionHook<
                   apiInputs?: { [key: string]: unknown },
                 ) => {
                   const apiRes = await invokeAPI(
-                    screen,
                     screenData,
                     apiName,
                     apiInputs,

--- a/packages/runtime/src/runtime/invokeApi.tsx
+++ b/packages/runtime/src/runtime/invokeApi.tsx
@@ -1,4 +1,4 @@
-import { DataFetcher, evaluate } from "@ensembleui/react-framework";
+import { DataFetcher } from "@ensembleui/react-framework";
 import type {
   Response,
   ScreenContextDefinition,
@@ -10,23 +10,18 @@ export const invokeAPI = async (
   screenData: ReturnType<typeof useScreenData>,
   apiName: string,
   apiInputs?: { [key: string]: unknown },
-  context?: { [key: string]: unknown },
 ): Promise<Response | undefined> => {
   const api = screenData.apis?.find((model) => model.name === apiName);
   if (!api) {
     return;
   }
-  const evaluatedInputs = evaluate<{ [key: string]: unknown }>(
-    screen,
-    JSON.stringify(apiInputs),
-    context,
-  );
+
   screenData.setData(api.name, {
     isLoading: true,
     isError: false,
     isSuccess: false,
   });
-  const res = await DataFetcher.fetch(api, { ...evaluatedInputs, ...context });
+  const res = await DataFetcher.fetch(api, { ...apiInputs });
   screenData.setData(api.name, res);
 
   return res;

--- a/packages/runtime/src/runtime/invokeApi.tsx
+++ b/packages/runtime/src/runtime/invokeApi.tsx
@@ -1,12 +1,7 @@
 import { DataFetcher } from "@ensembleui/react-framework";
-import type {
-  Response,
-  ScreenContextDefinition,
-  useScreenData,
-} from "@ensembleui/react-framework";
+import type { Response, useScreenData } from "@ensembleui/react-framework";
 
 export const invokeAPI = async (
-  screen: ScreenContextDefinition,
   screenData: ReturnType<typeof useScreenData>,
   apiName: string,
   apiInputs?: { [key: string]: unknown },


### PR DESCRIPTION
## Describe your changes
Remove evaluate from ensemble.invokeAPI as that was unnecessary.

### Screenshots [Optional]

## Issue ticket number and link

Closes #514 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
