### PR TITLE
Added defaultSelection ability

### DIFF
--- a/.changeset/eighty-roses-accept.md
+++ b/.changeset/eighty-roses-accept.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+added defaultSelected Row in datagrid

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -148,6 +148,7 @@ View:
                   allowSelection: true
                   selectionType: radio
                   allowResizableColumns: true
+                  defaultSelectedRowKeys: ["2"]
                   styles:
                     headerStyle:
                       backgroundColor: "white"
@@ -162,15 +163,15 @@ View:
                   item-template:
                     data:
                       [
-                        { key: "1", patient: "John", advocate: "Mike Ross" },
+                        { id: "1", patient: "John", advocate: "Mike Ross" },
                         {
-                          key: "2",
+                          id: "2",
                           patient: "Reuben",
                           advocate: "Harvey Dent",
                         },
                       ]
                     name: dummyData
-                    key: ${dummyData.key}
+                    key: ${dummyData.id}
                     template:
                       DataRow:
                         children:

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -76,6 +76,7 @@ export type GridProps = {
   selectionType?: "checkbox" | "radio";
   allowResizableColumns?: boolean;
   onRowsSelected?: EnsembleAction;
+  defaultSelectedRowKeys?: string[];
   DataColumns: Expression<DataColumn[] | string[]>;
   "item-template": {
     data: Expression<object>;
@@ -371,6 +372,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
                   setRowsSelected(selectedRows);
                   return onRowsSelectedCallback(selectedRowKeys, selectedRows);
                 },
+                defaultSelectedRowKeys: values?.defaultSelectedRowKeys,
               }
             : undefined
         }


### PR DESCRIPTION
## Describe your changes
- Added ability for users to have defaultRowSelection 
### Screenshots [Optional]
<img width="1680" alt="Screenshot 2024-04-22 at 7 28 33 PM" src="https://github.com/EnsembleUI/ensemble-react/assets/62849614/cd602714-62d0-4bb6-ad7c-4734c25cd657">

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
