### PR TITLE
Make Search widget symmetrical

### DIFF
--- a/.changeset/orange-planets-fail.md
+++ b/.changeset/orange-planets-fail.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+Make Search widget event symmetrical with data binding

--- a/apps/kitchen-sink/src/ensemble/widgets/Header.yaml
+++ b/apps/kitchen-sink/src/ensemble/widgets/Header.yaml
@@ -37,6 +37,9 @@ Widget:
                 name: findUsers
                 inputs:
                   search: ${search}
+            onSelect:
+              executeCode: |
+                console.log(value)
         - Row:
             styles:
               gap: 10


### PR DESCRIPTION
## Describe your changes

- Makes the output of onSelect symmetrical with the data binding coming in. Works around the restriction of AntD requiring that options have unique values (which objects are not accepted for)
- Skips client side filtering if onSearch callback is provided since we can assume the onSearch callback is doing the result filtering

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
