### PR TITLE
Fix showDialog's height to whatever user has given

### DIFF
--- a/.changeset/silent-melons-rescue.md
+++ b/.changeset/silent-melons-rescue.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+fix showDialog's height to whatever user has given

--- a/packages/runtime/src/runtime/modal.tsx
+++ b/packages/runtime/src/runtime/modal.tsx
@@ -173,6 +173,9 @@ export const ModalWrapper: React.FC<PropsWithChildren> = ({ children }) => {
         max-height: 100vh;
         max-width: 100vw;
       }
+      .ensemble-modal-${index} > div {
+        height: ${options.height || "auto"};
+      }
       .ensemble-modal-${index} .ant-modal-content {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## Describe your changes
fix showDialog's height to whatever user has given - `height:100%` inside options of showDialog was not working
refer to working of this showDialog https://github.com/EnsembleUI/ensemble-react/blob/2fd6f41dfbff187596e0763d3d74606cf2b8af0e/apps/kitchen-sink/src/ensemble/screens/actions.yaml#L250-L256

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
