### PR TITLE
fix calculation when triggering onScrollEnd for DataGrid and GridView

### DIFF
--- a/.changeset/angry-oranges-judge.md
+++ b/.changeset/angry-oranges-judge.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+fix calculation when triggering onScrollEnd for DataGrid and GridView

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -277,7 +277,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
       const { scrollTop, scrollHeight, clientHeight } = container;
 
       // Check if the user has scrolled to the bottom
-      if (scrollTop + clientHeight === scrollHeight) {
+      if (Math.round(scrollTop + clientHeight) === Math.round(scrollHeight)) {
         onScrollEndActionCallback();
       }
     },

--- a/packages/runtime/src/widgets/GridView.tsx
+++ b/packages/runtime/src/widgets/GridView.tsx
@@ -122,7 +122,7 @@ export const GridView: React.FC<GridViewProps> = ({
       const { scrollTop, scrollHeight, clientHeight } = container;
 
       // Check if the user has scrolled to the bottom
-      if (scrollTop + clientHeight === scrollHeight) {
+      if (Math.round(scrollTop + clientHeight) === Math.round(scrollHeight)) {
         onScrollEndActionCallback();
       }
     },


### PR DESCRIPTION
## Describe your changes
Refer working of this example:

https://github.com/EnsembleUI/ensemble-react/blob/b08c208d332313a5501f859090d028f77b31702e/apps/kitchen-sink/src/ensemble/screens/layouts.yaml#L124-L130
### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
