### PR TITLE
fix: added aspectRatio to match the chart with screen

### DIFF
--- a/packages/runtime/src/widgets/Charts/index.tsx
+++ b/packages/runtime/src/widgets/Charts/index.tsx
@@ -162,6 +162,7 @@ export const Chart: React.FC<ChartProps> = (props) => {
       style={{
         height: props.styles?.height ?? "100%",
         width: props.styles?.width ?? "100%",
+        aspectRatio: 2,
         ...(props.styles?.visible === false ? { display: "none" } : undefined),
       }}
     >


### PR DESCRIPTION
## Describe your changes
Added aspectRatio to match the chart size with the screen

### Screenshots [Optional]

## Issue ticket number and link

Closes #560 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
