### PR TITLE
fix: added loading attribute in button

### DIFF
--- a/.changeset/thirty-wolves-carry.md
+++ b/.changeset/thirty-wolves-carry.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+added loading attribute in button widget

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -996,6 +996,37 @@ View:
                     template:
                       Text:
                         text: ${product.title}
+
+        - Card:
+            styles:
+              maxWidth: unset
+              width: unset
+              gap: 10px
+            children:
+              - Text:
+                  styles:
+                    names: heading-3
+                  text: Button with icons and loading
+              - Row:
+                  styles:
+                    gap: 4
+                  children:
+                    - Button:
+                        label: Toggle loaders
+                        onTap:
+                          executeCode: |
+                            iconButton1.setLoading(!iconButton1.loading)
+                            iconButton2.setLoading(!iconButton2.loading)
+                    - Button:
+                        id: iconButton1
+                        label: Hello
+                        endingIcon:
+                          name: ArrowBack
+                    - Button:
+                        id: iconButton2
+                        label: Hello
+                        startingIcon:
+                          name: ArrowBack
 API:
   getDummyProducts:
     method: GET

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -1018,11 +1018,15 @@ View:
                             iconButton1.setLoading(!iconButton1.loading)
                             iconButton2.setLoading(!iconButton2.loading)
                     - Button:
+                        styles:
+                          width: 50px
                         id: iconButton1
                         label: Hello
                         endingIcon:
                           name: ArrowBack
                     - Button:
+                        styles:
+                          minWidth: 50px
                         id: iconButton2
                         label: Hello
                         startingIcon:

--- a/packages/runtime/src/widgets/Button.tsx
+++ b/packages/runtime/src/widgets/Button.tsx
@@ -73,14 +73,18 @@ export const Button: React.FC<ButtonProps> = ({ id, onTap, ...rest }) => {
             : undefined),
         }}
       >
-        {values?.startingIcon ? (
+        {!loading && (
           <>
-            <Icon {...values.startingIcon} />
-            &nbsp;
+            {values?.startingIcon ? (
+              <>
+                <Icon {...values.startingIcon} />
+                &nbsp;
+              </>
+            ) : null}
+            {values?.label}
+            {values?.endingIcon ? <Icon {...values.endingIcon} /> : null}
           </>
-        ) : null}
-        {values?.label}
-        {values?.endingIcon ? <Icon {...values.endingIcon} /> : null}
+        )}
       </AntButton>
     );
   }, [onClickCallback, rootRef, values, loading]);

--- a/packages/runtime/src/widgets/Button.tsx
+++ b/packages/runtime/src/widgets/Button.tsx
@@ -1,7 +1,13 @@
 import type { EnsembleAction, Expression } from "@ensembleui/react-framework";
 import { useRegisterBindings } from "@ensembleui/react-framework";
 import { Button as AntButton, Form as AntForm } from "antd";
-import { type MouseEvent, useCallback, useMemo } from "react";
+import {
+  type MouseEvent,
+  useCallback,
+  useMemo,
+  useState,
+  useEffect,
+} from "react";
 import { WidgetRegistry } from "../registry";
 import type { EnsembleWidgetProps, IconProps } from "../shared/types";
 import { useEnsembleAction } from "../runtime/hooks/useEnsembleAction";
@@ -19,9 +25,11 @@ export type ButtonProps = {
     textColor?: string;
     gap?: string | number;
   };
+  loading?: boolean;
 } & EnsembleWidgetProps;
 
 export const Button: React.FC<ButtonProps> = ({ id, onTap, ...rest }) => {
+  const [loading, setLoading] = useState<boolean>(rest.loading || false);
   const action = useEnsembleAction(onTap);
   const onClickCallback = useCallback(
     (e?: MouseEvent) => {
@@ -34,15 +42,23 @@ export const Button: React.FC<ButtonProps> = ({ id, onTap, ...rest }) => {
     [action],
   );
 
-  const { values, rootRef } = useRegisterBindings(rest, id, {
+  const { values, rootRef } = useRegisterBindings({ ...rest, loading }, id, {
     click: onClickCallback,
+    setLoading,
   });
+
+  useEffect(() => {
+    if (values?.loading !== undefined) {
+      setLoading(values.loading);
+    }
+  }, [values?.loading]);
 
   const ButtonComponent = useMemo(() => {
     return (
       <AntButton
         disabled={values?.disabled ?? false}
         htmlType={values?.submitForm === true ? "submit" : "button"}
+        loading={loading}
         onClick={onClickCallback}
         ref={rootRef}
         style={{
@@ -67,7 +83,7 @@ export const Button: React.FC<ButtonProps> = ({ id, onTap, ...rest }) => {
         {values?.endingIcon ? <Icon {...values.endingIcon} /> : null}
       </AntButton>
     );
-  }, [onClickCallback, rootRef, values]);
+  }, [onClickCallback, rootRef, values, loading]);
 
   if (values?.submitForm) {
     return (


### PR DESCRIPTION
## Describe your changes
Added loading attribute in button.

Can set loading attribute by two way
1. by setting `loading` attribute in EDL
2. by setting `setLoading` through `executecode`

Example:
```yaml
Button:
  label: toggle
  loader: ${ensemble.storage.get('loaderStat')}
```

```yaml
onTap:
  executeCode: |
    toggleButton.setLoading(true)
```
                  

### Screenshots [Optional]

https://github.com/EnsembleUI/ensemble-react/assets/31651612/c2dc5096-302b-43dc-99fc-1ae9ac302b99



## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
