### PR TITLE
fix: reset options when there are no options on search query

### DIFF
--- a/.changeset/strange-pumpkins-brake.md
+++ b/.changeset/strange-pumpkins-brake.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+reset options when there are no options on search query

--- a/packages/runtime/src/widgets/Search.tsx
+++ b/packages/runtime/src/widgets/Search.tsx
@@ -18,7 +18,7 @@ import type {
 } from "@ensembleui/react-framework";
 import { AutoComplete, Input } from "antd";
 import { SearchOutlined } from "@mui/icons-material";
-import { get, isEmpty, isNull, isNumber } from "lodash-es";
+import { get, isNull, isNumber } from "lodash-es";
 import { WidgetRegistry } from "../registry";
 import type {
   EnsembleWidgetProps,
@@ -75,10 +75,6 @@ export const Search: React.FC<SearchProps> = ({
   const onSelectAction = useEnsembleAction(onSelect);
 
   useEffect(() => {
-    if (isEmpty(namedData)) {
-      return;
-    }
-
     const newOptions = namedData.map((item) => {
       const itemData = itemTemplate?.name
         ? (get(item, itemTemplate.name) as unknown)
@@ -121,7 +117,7 @@ export const Search: React.FC<SearchProps> = ({
         onSearchAction.callback({ search: searchValue });
       }
     },
-    onSearch?.debounceMs,
+    onSearch?.debounceMs || 500,
     [searchValue],
   );
 

--- a/packages/runtime/src/widgets/Search.tsx
+++ b/packages/runtime/src/widgets/Search.tsx
@@ -117,7 +117,7 @@ export const Search: React.FC<SearchProps> = ({
         onSearchAction.callback({ search: searchValue });
       }
     },
-    onSearch?.debounceMs || 500,
+    onSearch?.debounceMs || 0,
     [searchValue],
   );
 


### PR DESCRIPTION
## Describe your changes
Reset options when there are no options on search query

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
