### PR TITLE
fix allowSelection and selectionType binding of Datagrid

### DIFF
--- a/.changeset/short-insects-pump.md
+++ b/.changeset/short-insects-pump.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+fix allowSelection and selectionType binding of Datagrid

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -155,8 +155,8 @@ View:
                   onRowsSelected:
                     executeCode: |
                       console.log("data", selectedRows, selectedRowKeys);
-                  allowSelection: true
-                  selectionType: radio
+                  allowSelection: ${1===1}
+                  selectionType: '${1===10 ? "checkbox" : "radio"}'
                   allowResizableColumns: true
                   defaultSelectedRowKeys: ["2"]
                   styles:

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -286,6 +286,18 @@ export const DataGrid: React.FC<GridProps> = (props) => {
     setCurPage(values?.curPage || 1);
   }, [values?.pageSize, values?.curPage]);
 
+  useEffect(() => {
+    if (values?.allowSelection !== undefined) {
+      setAllowSelection(values.allowSelection);
+    }
+  }, [values?.allowSelection]);
+
+  useEffect(() => {
+    if (values?.selectionType !== undefined) {
+      setSelectionType(values.selectionType);
+    }
+  }, [values?.selectionType]);
+
   // handle column resize
   const handleResize =
     (index: number) =>


### PR DESCRIPTION
## Describe your changes
Bindings for allowSelection and selectionType were not working.

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
