### PR TITLE
fix: tabBar stretch options

### DIFF
--- a/.changeset/ninety-bats-taste.md
+++ b/.changeset/ninety-bats-taste.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+fix: tabBar stretch option

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -759,6 +759,7 @@ View:
               tabBackgroundColor: orange
               tabNavBottomBorderShow: false
               tabNavBorderRadius: 10
+              tabNavStretch: true
             styles:
               activeTabBackgroundColor: red
               activeTabColor: white
@@ -766,6 +767,7 @@ View:
               tabContentHolderBackgroundColor: green
               tabContentHolderBorderRadius: 10
               tabContentHolderPadding: 10px 5px
+              tabPosition: "top"
 
         - DataGrid:
             DataColumns:

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -759,7 +759,6 @@ View:
               tabBackgroundColor: orange
               tabNavBottomBorderShow: false
               tabNavBorderRadius: 10
-              tabNavStretch: true
             styles:
               activeTabBackgroundColor: red
               activeTabColor: white
@@ -767,7 +766,7 @@ View:
               tabContentHolderBackgroundColor: green
               tabContentHolderBorderRadius: 10
               tabContentHolderPadding: 10px 5px
-              tabPosition: "top"
+              tabPosition: "stretch"
 
         - DataGrid:
             DataColumns:

--- a/packages/runtime/src/widgets/TabBar.tsx
+++ b/packages/runtime/src/widgets/TabBar.tsx
@@ -3,6 +3,7 @@ import { useRegisterBindings } from "@ensembleui/react-framework";
 import type { Expression, EnsembleWidget } from "@ensembleui/react-framework";
 import { Tabs, ConfigProvider } from "antd";
 import { zip } from "lodash-es";
+import { TabsPosition } from "antd/es/tabs";
 import type {
   EnsembleWidgetProps,
   EnsembleWidgetStyles,
@@ -28,12 +29,13 @@ export interface TabStyles {
   tabNavBorderRadius: string;
   tabNavBottomBorderShow: boolean;
   tabColor: string;
+  tabNavStretch: boolean;
 }
 
 export interface TabBarStyles extends EnsembleWidgetStyles {
   inkBarShow: boolean;
   activeTabBackgroundColor: string;
-  tabPosition: "start" | "stretch";
+  tabPosition: TabsPosition;
   tabPadding: string;
   tabFontSize: number;
   tabFontWeight: string;
@@ -116,6 +118,7 @@ export const TabBar: React.FC<TabBarProps> = (props) => {
       background-color: ${props.tabStyles?.tabNavBackgroundColor || "none"};
       border-radius: ${props.tabStyles?.tabNavBorderRadius || 0}px !important;
       padding: ${props.tabStyles?.tabNavPadding || "inherit"};
+      max-width: ${!props.tabStyles?.tabNavStretch ? "fit-content" : "unset"}
     }
 
     .ant-tabs {
@@ -174,6 +177,7 @@ export const TabBar: React.FC<TabBarProps> = (props) => {
       <Tabs
         defaultActiveKey={setDefaultSelectedTab()}
         style={{ ...values?.styles }}
+        tabPosition={values?.styles?.tabPosition}
       >
         {tabs.map(([tabItem, widget]) => (
           <TabPane

--- a/packages/runtime/src/widgets/TabBar.tsx
+++ b/packages/runtime/src/widgets/TabBar.tsx
@@ -3,7 +3,6 @@ import { useRegisterBindings } from "@ensembleui/react-framework";
 import type { Expression, EnsembleWidget } from "@ensembleui/react-framework";
 import { Tabs, ConfigProvider } from "antd";
 import { zip } from "lodash-es";
-import { TabsPosition } from "antd/es/tabs";
 import type {
   EnsembleWidgetProps,
   EnsembleWidgetStyles,
@@ -29,13 +28,12 @@ export interface TabStyles {
   tabNavBorderRadius: string;
   tabNavBottomBorderShow: boolean;
   tabColor: string;
-  tabNavStretch: boolean;
 }
 
 export interface TabBarStyles extends EnsembleWidgetStyles {
   inkBarShow: boolean;
   activeTabBackgroundColor: string;
-  tabPosition: TabsPosition;
+  tabPosition: "start" | "stretch";
   tabPadding: string;
   tabFontSize: number;
   tabFontWeight: string;
@@ -114,11 +112,14 @@ export const TabBar: React.FC<TabBarProps> = (props) => {
       };
     }
 
+    .ant-tabs-nav-list {
+      width: 100%
+    }
+
     .ant-tabs > .ant-tabs-nav {
       background-color: ${props.tabStyles?.tabNavBackgroundColor || "none"};
       border-radius: ${props.tabStyles?.tabNavBorderRadius || 0}px !important;
       padding: ${props.tabStyles?.tabNavPadding || "inherit"};
-      max-width: ${!props.tabStyles?.tabNavStretch ? "fit-content" : "unset"}
     }
 
     .ant-tabs {
@@ -131,6 +132,15 @@ export const TabBar: React.FC<TabBarProps> = (props) => {
       background: ${props.styles?.tabBackgroundColor || "inherit"} !important;
       color: ${props.tabStyles?.tabColor || "inherit"} !important;
     }
+
+    ${
+      values?.styles?.tabPosition === "stretch"
+        ? `.ant-tabs-nav-list .ant-tabs-tab:nth-last-child(2) {
+      flex: 1
+    }`
+        : ""
+    }
+
 
     .ant-tabs .ant-tabs-tab+.ant-tabs-tab {
       margin-left: 10px !important;
@@ -177,7 +187,6 @@ export const TabBar: React.FC<TabBarProps> = (props) => {
       <Tabs
         defaultActiveKey={setDefaultSelectedTab()}
         style={{ ...values?.styles }}
-        tabPosition={values?.styles?.tabPosition}
       >
         {tabs.map(([tabItem, widget]) => (
           <TabPane


### PR DESCRIPTION
## Describe your changes
Added support to choose tabBar stretch option

### Screenshots [Optional]
<img width="1331" alt="image" src="https://github.com/EnsembleUI/ensemble-react/assets/31651612/ad141c42-9e04-4bcf-9a46-95d337028d75">

<img width="1261" alt="image" src="https://github.com/EnsembleUI/ensemble-react/assets/31651612/784a75ee-33b5-409a-9817-8a6e2b15c833">


## Issue ticket number and link

Closes #593 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
