### PR TITLE
Show just the hintText in case of empty value of Date widget

### DIFF
--- a/.changeset/clever-phones-play.md
+++ b/.changeset/clever-phones-play.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+show just the hintText in case of empty value of Date widget

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -117,9 +117,19 @@ View:
                           - label: Option 2
                             value: option2
                     - Date:
-                        id: date
-                        label: Date
-                        hintText: Choose date
+                        id: date0
+                        label: Date 0
+                        hintText: Choose date 0
+                    - Date:
+                        id: date1
+                        label: Date 1
+                        value: ""
+                        hintText: Choose date 1
+                    - Date:
+                        id: date2
+                        label: Date 2
+                        value: "2024/04/04"
+                        hintText: Choose date 2
                     - Button:
                         submitForm: true
                         label: Submit
@@ -223,11 +233,11 @@ View:
                             value: option1
                           - label: Option 2
                             value: option2
-                    - Date:
-                        id: initail_date
-                        label: Date
-                        value: "2024/04/04"
-                        hintText: Choose date
+                    # - Date:
+                    #     id: initail_date
+                    #     label: Date
+                    #     value: "2024/04/04"
+                    #     hintText: Choose date
                     - Button:
                         submitForm: true
                         label: Submit

--- a/packages/runtime/src/widgets/Form/Date/Date.tsx
+++ b/packages/runtime/src/widgets/Form/Date/Date.tsx
@@ -68,7 +68,9 @@ export const Date: React.FC<DateProps> = (props) => {
 
   useEffect(() => {
     if (!value) {
-      setValue(String(dayjs(values?.initialValue)));
+      setValue(
+        values?.initialValue ? String(dayjs(values.initialValue)) : undefined,
+      );
     }
   }, [values]);
 
@@ -77,7 +79,7 @@ export const Date: React.FC<DateProps> = (props) => {
   useEffect(() => {
     if (formInstance) {
       formInstance.setFieldsValue({
-        [values?.id ?? values?.label ?? ""]: dayjs(value),
+        [values?.id ?? values?.label ?? ""]: value ? dayjs(value) : undefined,
       });
     }
   }, [value, formInstance]);


### PR DESCRIPTION
## Describe your changes
When `value: ''` or `value: null` is passed in EDL of Date widget, we show just the hintText instead of "Invalid Date" so that 
1. picker is in workable
2. we can initialize Date widget with empty selected date by default (need in Atlas in manager filters)

### Screenshots [Optional]
Before:

https://github.com/EnsembleUI/ensemble-react/assets/32386713/3c40eea1-766a-44a0-8b20-f5d021608150


After:

https://github.com/EnsembleUI/ensemble-react/assets/32386713/e04defc2-c6c0-42f8-af60-ae4f9137502b


## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
