### PR TITLE
616 need support for inputtype and validator in textinput widget

### DIFF
--- a/.changeset/neat-books-carry.md
+++ b/.changeset/neat-books-carry.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+support inputType, validator and mask on TextInput widget

--- a/.changeset/neat-books-carry.md
+++ b/.changeset/neat-books-carry.md
@@ -4,3 +4,4 @@
 ---
 
 support inputType, validator and mask on TextInput widget
+support validateOnUserInteraction on form items

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -90,9 +90,24 @@ View:
                     - TextInput:
                         id: formTextInput
                         value: ${ensemble.storage.get('inputVal')}
+                        hintText: (123) 456-7890
+                        mask: "(###) ###-####"
+                        inputType: phone
                         label:
                           Text:
                             text: Text input
+                    - TextInput:
+                        id: minMaxTextInput
+                        validator:
+                          minLength: 4
+                          maxLength: 10
+                        label: Text input with min and max length
+                    - TextInput:
+                        id: regexTextInput
+                        validator:
+                          regex: "[0-5]"
+                          regexError: "Only numbers 0 to 5 are allowed"
+                        label: Text input with regex
                     - MultiSelect:
                         id: multiselectoptions1
                         label: Choose multiple from API or storage

--- a/packages/runtime/src/widgets/Form/FormItem.tsx
+++ b/packages/runtime/src/widgets/Form/FormItem.tsx
@@ -15,7 +15,7 @@ export type EnsembleFormItemProps<T> = FormItemProps & {
 export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
   props,
 ) => {
-  const { values, ...rest } = props;
+  const { values, rules, ...rest } = props;
   const { backgroundColor: _, ...formItemStyles } = values?.styles ?? {};
   const formInstance = AntForm.useFormInstance();
 
@@ -39,7 +39,7 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
         ) : null
       }
       name={formInstance ? values?.id ?? values?.label : undefined}
-      rules={rest.rules?.concat({ required: Boolean(values?.required) })}
+      rules={rules?.concat([{ required: Boolean(values?.required) }])}
       validateTrigger={
         values?.validateOnUserInteraction === true ? "onChange" : "onSubmit"
       }

--- a/packages/runtime/src/widgets/Form/FormItem.tsx
+++ b/packages/runtime/src/widgets/Form/FormItem.tsx
@@ -39,7 +39,10 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
         ) : null
       }
       name={formInstance ? values?.id ?? values?.label : undefined}
-      rules={[{ required: Boolean(values?.required) }]}
+      rules={rest.rules?.concat({ required: Boolean(values?.required) })}
+      validateTrigger={
+        values?.validateOnUserInteraction === true ? "onChange" : "onSubmit"
+      }
       style={{
         margin: "0px",
         ...(values?.styles?.visible === false

--- a/packages/runtime/src/widgets/Form/TextInput.tsx
+++ b/packages/runtime/src/widgets/Form/TextInput.tsx
@@ -140,7 +140,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     if (values?.mask && patternValue) {
       rulesArray.push({
         pattern: new RegExp(patternValue),
-        message: `The field does not match the mask ${values.mask}`,
+        message: `The value must be of the format ${values.mask}`,
       });
     }
 

--- a/packages/runtime/src/widgets/Form/TextInput.tsx
+++ b/packages/runtime/src/widgets/Form/TextInput.tsx
@@ -1,12 +1,13 @@
 import { Input, Form } from "antd";
 import type { Expression } from "@ensembleui/react-framework";
 import { useRegisterBindings } from "@ensembleui/react-framework";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { EnsembleWidgetProps } from "../../shared/types";
 import { WidgetRegistry } from "../../registry";
 import type { TextStyles } from "../Text";
 import type { FormInputProps } from "./types";
 import { EnsembleFormItem } from "./FormItem";
+import { Rule } from "antd/es/form";
 
 const widgetName = "TextInput";
 
@@ -15,6 +16,14 @@ export type TextInputProps = {
   labelStyle?: TextStyles;
   multiLine?: Expression<boolean>;
   maxLines?: number;
+  inputType?: "email" | "phone" | "number" | "text" | "url"; //| "ipAddress";
+  mask?: string;
+  validator?: {
+    minLength?: number;
+    maxLength?: number;
+    regex?: string;
+    regexError?: string;
+  };
 } & EnsembleWidgetProps<TextStyles> &
   FormInputProps<string>;
 
@@ -44,8 +53,102 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     }
   }, [value, formInstance, values?.id, values?.label]);
 
+  const inputType = useMemo(() => {
+    switch (values?.inputType) {
+      case "email":
+        return "email";
+      case "phone":
+        return "tel";
+      case "number":
+        return "number";
+      case "url":
+        return "url";
+      default:
+        return "text";
+    }
+  }, [values?.inputType]);
+
+  const patternValue = useMemo((): string | undefined | RegExp => {
+    if (!values?.mask) {
+      return;
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#overview
+    const special = [
+      "[",
+      "]",
+      "\\",
+      "/",
+      "^",
+      "$",
+      ".",
+      "|",
+      "?",
+      "*",
+      "+",
+      "(",
+      ")",
+      "{",
+      "}",
+    ];
+
+    let pattern = "^(?:";
+    for (const char of values.mask) {
+      switch (char) {
+        case "#":
+          pattern += "[0-9]"; // Match any digit
+          break;
+        case "A":
+          pattern += "[a-zA-Z]"; // Match any letter
+          break;
+        default:
+          if (special.includes(char)) {
+            pattern += `\\${char}`; // Escape special characters
+          } else {
+            pattern += char; // Include the character literally
+          }
+          break;
+      }
+    }
+    return pattern + ")$";
+  }, [values?.mask]);
+
+  const rules = useMemo(() => {
+    const rulesArray: Rule[] = [];
+
+    if (values?.validator?.minLength) {
+      rulesArray.push({
+        min: values.validator.minLength,
+        message: `The field  must be at least ${values.validator.minLength} characters long`,
+      });
+    }
+
+    if (values?.validator?.maxLength) {
+      rulesArray.push({
+        max: values.validator.maxLength,
+        message: `The field must be at most ${values.validator.maxLength} characters long`,
+      });
+    }
+
+    if (values?.validator?.regex) {
+      rulesArray.push({
+        pattern: new RegExp(values.validator.regex),
+        message: values.validator.regexError || "The field has invalid value",
+      });
+    }
+
+    if (values?.mask && patternValue) {
+      rulesArray.push({
+        pattern: new RegExp(patternValue),
+        message: `The field does not match the mask ${values.mask}`,
+      });
+    }
+
+    return rulesArray;
+  }, [values?.validator, values?.mask]);
+
   return (
-    <EnsembleFormItem valuePropName="value" values={values}>
+    <EnsembleFormItem valuePropName="value" values={values} rules={rules}>
       {values?.multiLine ? (
         <Input.TextArea
           defaultValue={values.value}
@@ -73,6 +176,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
               ? { display: "none" }
               : undefined),
           }}
+          type={inputType}
           value={value}
         />
       )}

--- a/packages/runtime/src/widgets/Form/types.d.ts
+++ b/packages/runtime/src/widgets/Form/types.d.ts
@@ -11,4 +11,5 @@ export type FormInputProps<T> = EnsembleWidgetProps & {
   required?: Expression<boolean>;
   enabled?: Expression<boolean>;
   labelStyle?: EnsembleWidgetStyles;
+  validateOnUserInteraction?: Expression<boolean>;
 };


### PR DESCRIPTION
## Describe your changes
- support inputType, validator and mask on TextInput widget
- support validateOnUserInteraction on form items

### Screenshots [Optional]

https://github.com/EnsembleUI/ensemble-react/assets/32386713/555fcc04-a6d4-453d-95e7-c5330e05a932


## Issue ticket number and link

Closes #616

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
