### PR TITLE
fix: widget input initialized supports

### DIFF
--- a/.changeset/tricky-elephants-wait.md
+++ b/.changeset/tricky-elephants-wait.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+Fix widget input intialized when no inputs have been passed

--- a/packages/runtime/src/runtime/customWidget.tsx
+++ b/packages/runtime/src/runtime/customWidget.tsx
@@ -20,8 +20,17 @@ export interface CustomWidgetProps {
 export const createCustomWidget = (
   widget: CustomWidgetModel,
 ): React.FC<CustomWidgetProps> => {
+  const tempVar = widget.inputs.reduce(
+    (acc, item: string) => {
+      acc[item] = undefined;
+      return acc;
+    },
+    {} as { [key: string]: undefined },
+  );
+
   const CustomWidget: React.FC<CustomWidgetProps> = ({ inputs }) => {
     const { values } = useRegisterBindings<{ [key: string]: unknown }>({
+      ...tempVar,
       ...inputs,
       widgetName: widget.name,
     });


### PR DESCRIPTION
## Describe your changes
Added support for widget input intialized

### Screenshots [Optional]

## Issue ticket number and link

Closes #590 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
