### PR TITLE
fix: added support for access environment variables through env

### DIFF
--- a/.changeset/shiny-singers-shout.md
+++ b/.changeset/shiny-singers-shout.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-framework": patch
+"@ensembleui/react-kitchen-sink": patch
+---
+
+added support of access environment variables through env into expressions

--- a/apps/kitchen-sink/src/ensemble/config.yaml
+++ b/apps/kitchen-sink/src/ensemble/config.yaml
@@ -1,2 +1,3 @@
 environmentVariables:
   googleOAuthId: 726646987043-9i1it0ll0neojkf7f9abkagbe66kqe4a.apps.googleusercontent.com
+  randomId: 8729435004

--- a/apps/kitchen-sink/src/ensemble/screens/home.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/home.yaml
@@ -9,6 +9,7 @@ View:
       Header:
 
   styles:
+    scrollableView: true
     backgroundColor: ${colors.primary['200']}
 
   body:
@@ -176,6 +177,24 @@ View:
             styles:
               margin: 10px 0px
             id: socketReceivedMessage
+
+        - Divider:
+
+        - Text:
+            styles:
+              names: heading-1
+            text: Access environment values using env
+
+        - Row:
+            styles:
+              gap: 8
+            children:
+              - Text:
+                  fontWeight: 900
+                  text: "Random Id :"
+
+              - Text:
+                  text: ${env.randomId}
 
 Global:
   scriptName: test.js

--- a/packages/framework/src/evaluate/binding.ts
+++ b/packages/framework/src/evaluate/binding.ts
@@ -81,6 +81,7 @@ export const createBindingAtom = <T = unknown>(
         application: {
           theme: get(themeAtom),
         },
+        env: get(envAtom),
       },
       screenContext: {
         inputs: get(screenInputAtom),

--- a/packages/framework/src/evaluate/context.ts
+++ b/packages/framework/src/evaluate/context.ts
@@ -36,5 +36,7 @@ export const createEvaluationContext = ({
     screenContext.widgets,
     screenContext.data,
   );
-  return merge({}, { ensemble }, appInputs, screenInputs, context);
+
+  const env = applicationContext.env;
+  return merge({}, { ensemble, env }, appInputs, screenInputs, context);
 };


### PR DESCRIPTION
## Describe your changes
Added support for access environment variables through env

example
```yaml
- Text:
   text: ${env.randomId}
```

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
