### PR TITLE
fix: onload hook invokation order

### DIFF
--- a/.changeset/calm-jobs-enjoy.md
+++ b/.changeset/calm-jobs-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+fix onload hook invokation order for screen and customWidgets

--- a/apps/kitchen-sink/src/App.tsx
+++ b/apps/kitchen-sink/src/App.tsx
@@ -10,10 +10,13 @@ import FormsYAML from "./ensemble/screens/forms.yaml";
 import CustomWidgetsYAML from "./ensemble/screens/customWidgets.yaml";
 import HelpYAML from "./ensemble/screens/help.yaml";
 import ProductYAML from "./ensemble/screens/product.yaml";
+import TestYAML from "./ensemble/screens/test.yaml";
 // Widgets
 import HeaderWidgetYAML from "./ensemble/widgets/Header.yaml";
 import StyledTextWidgetYAML from "./ensemble/widgets/StyledText.yaml";
 import DispatchButtonWidgetYAML from "./ensemble/widgets/Button.yaml";
+import CustomWidget1 from "./ensemble/widgets/CustomWidget1.yaml";
+import CustomWidget2 from "./ensemble/widgets/CustomWidget2.yaml";
 // Scripts
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
@@ -89,6 +92,16 @@ const testApp: ApplicationDTO = {
       name: "DispatchButton",
       content: String(DispatchButtonWidgetYAML),
     },
+    {
+      id: "CustomWidget1",
+      name: "CustomWidget1",
+      content: String(CustomWidget1),
+    },
+    {
+      id: "CustomWidget2",
+      name: "CustomWidget2",
+      content: String(CustomWidget2),
+    },
   ],
   screens: [
     {
@@ -141,6 +154,11 @@ const testApp: ApplicationDTO = {
       name: "Product",
       path: "/product/:product_name",
       content: String(ProductYAML),
+    },
+    {
+      id: "test",
+      name: "Test",
+      content: String(TestYAML),
     },
   ],
   config: EnsembleConfig,

--- a/apps/kitchen-sink/src/ensemble/screens/home.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/home.yaml
@@ -12,7 +12,6 @@ View:
   styles:
     scrollableView: true
     backgroundColor: ${colors.primary['200']}
-    scrollableView: true
 
   body:
     Column:
@@ -196,7 +195,6 @@ View:
               margin: 10px 0px
             id: socketReceivedMessage
 
-
         - Text:
             styles:
               names: heading-1
@@ -237,7 +235,6 @@ View:
                   text: Expression with Strings
               - Text:
                   text: ${ensemble.storage.get('yyy')} style
-
 
         - Row:
             styles:

--- a/apps/kitchen-sink/src/ensemble/screens/menu.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/menu.yaml
@@ -51,6 +51,9 @@ ViewGroup:
       - label: Help
         icon: HelpOutlineOutlined
         page: help
+      - label: Test
+        icon: ExtensionOutlined
+        page: test
     footer:
       Row:
         styles:

--- a/apps/kitchen-sink/src/ensemble/screens/test.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/test.yaml
@@ -1,0 +1,13 @@
+View:
+  onLoad:
+    executeCode: |
+      console.log('Test screen loaded')
+      ensemble.storage.set('testOnLoad' , true)
+
+  body:
+    Column:
+      children:
+        - Text:
+            text: Test screen
+        - CustomWidget1:
+        - CustomWidget2:

--- a/apps/kitchen-sink/src/ensemble/widgets/CustomWidget1.yaml
+++ b/apps/kitchen-sink/src/ensemble/widgets/CustomWidget1.yaml
@@ -1,0 +1,13 @@
+Widget:
+  onLoad:
+    executeCode: |
+      console.log('CustomWidget1 loaded')
+      ensemble.storage.set('testOnWidget1' , true)
+
+  body:
+    Button:
+      label: Custom widget 1
+      onTap:
+        executeCode:
+          body: |
+            ensemble.storage.set('testOnButton1' , true)

--- a/apps/kitchen-sink/src/ensemble/widgets/CustomWidget2.yaml
+++ b/apps/kitchen-sink/src/ensemble/widgets/CustomWidget2.yaml
@@ -1,0 +1,13 @@
+Widget:
+  onLoad:
+    executeCode: |
+      console.log('CustomWidget2 loaded')
+      ensemble.storage.set('testOnWidget2' , true)
+
+  body:
+    Button:
+      label: Custom widget 2
+      onTap:
+        executeCode:
+          body: |
+            ensemble.storage.set('testOnButton2' , true)

--- a/packages/runtime/src/runtime/customWidget.tsx
+++ b/packages/runtime/src/runtime/customWidget.tsx
@@ -40,9 +40,8 @@ export const createCustomWidget = (
     return (
       <CustomEventScopeProvider value={events}>
         <CustomScopeProvider value={values ?? inputs}>
-          <OnLoadAction action={widget?.onLoad} context={values ?? inputs}>
-            {EnsembleRuntime.render([widget.body])}
-          </OnLoadAction>
+          <OnLoadAction action={widget?.onLoad} context={values ?? inputs} />
+          {EnsembleRuntime.render([widget.body])}
         </CustomScopeProvider>
       </CustomEventScopeProvider>
     );

--- a/packages/runtime/src/runtime/screen.tsx
+++ b/packages/runtime/src/runtime/screen.tsx
@@ -94,10 +94,9 @@ export const EnsembleScreen: React.FC<EnsembleScreenProps> = ({
       screen={screen}
     >
       <ModalWrapper>
-        <OnLoadAction action={screen.onLoad} context={{ ...mergedInputs }}>
-          <EnsembleHeader header={screen.header} />
-          <EnsembleBody body={screen.body} styles={screen.styles} />
-        </OnLoadAction>
+        <OnLoadAction action={screen.onLoad} context={{ ...mergedInputs }} />
+        <EnsembleHeader header={screen.header} />
+        <EnsembleBody body={screen.body} styles={screen.styles} />
         <EnsembleFooter footer={screen.footer} />
       </ModalWrapper>
     </ScreenContextProvider>


### PR DESCRIPTION
## Describe your changes
fix order of onload hook invokation in screen and custom widgets

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
