### PR TITLE
Date widget: fix setting state value to binding value on subsequent load of widget

### DIFF
--- a/.changeset/weak-rats-work.md
+++ b/.changeset/weak-rats-work.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+Date widget: fix setting state value to binding value on subsequent load of widget

--- a/packages/runtime/src/widgets/Form/Date/Date.tsx
+++ b/packages/runtime/src/widgets/Form/Date/Date.tsx
@@ -64,8 +64,8 @@ export const Date: React.FC<DateProps> = (props) => {
       setValue(
         values?.initialValue ? String(dayjs(values.initialValue)) : undefined,
       );
-    } else if (values?.value) {
-      setValue(values.value);
+    } else if (values?.value && dayjs(values.value).isValid()) {
+      setValue(String(dayjs(values.value)));
     }
   }, [values]);
 

--- a/packages/runtime/src/widgets/Form/Date/Date.tsx
+++ b/packages/runtime/src/widgets/Form/Date/Date.tsx
@@ -4,20 +4,13 @@ import { DatePicker, Form } from "antd";
 import { useState, useCallback, useEffect } from "react";
 import dayjs from "dayjs";
 import { WidgetRegistry } from "../../../registry";
-import type {
-  EnsembleWidgetProps,
-  EnsembleWidgetStyles,
-} from "../../../shared/types";
+import type { EnsembleWidgetProps } from "../../../shared/types";
 import { useEnsembleAction } from "../../../runtime/hooks/useEnsembleAction";
 import type { FormInputProps } from "../types";
 import { EnsembleFormItem } from "../FormItem";
 import { DateDisplayFormat } from "./utils/DateConstants";
 
 const widgetName = "Date";
-
-type DateStyles = {
-  visible?: boolean;
-} & EnsembleWidgetStyles;
 
 export type DateProps = {
   initialValue?: Expression<string>;
@@ -26,7 +19,7 @@ export type DateProps = {
   showCalendarIcon?: boolean;
   onChange?: EnsembleAction;
 } & FormInputProps<string> &
-  EnsembleWidgetProps<DateStyles>;
+  EnsembleWidgetProps;
 
 export const Date: React.FC<DateProps> = (props) => {
   const [value, setValue] = useState<string>();
@@ -67,10 +60,12 @@ export const Date: React.FC<DateProps> = (props) => {
   };
 
   useEffect(() => {
-    if (!value) {
+    if (!value && !values?.value) {
       setValue(
         values?.initialValue ? String(dayjs(values.initialValue)) : undefined,
       );
+    } else if (values?.value) {
+      setValue(values.value);
     }
   }, [values]);
 


### PR DESCRIPTION
## Describe your changes

### Screenshots [Optional]

https://github.com/EnsembleUI/ensemble-react/assets/32386713/3e0092b1-96ab-41ba-8038-2fd88f98ab85


https://github.com/EnsembleUI/ensemble-react/assets/32386713/904211db-5384-4871-806a-dc5ed38e47d5


## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
