### PR TITLE
692 support additional styles on collapsible header especially color

### DIFF
--- a/.changeset/short-pens-flash.md
+++ b/.changeset/short-pens-flash.md
@@ -1,6 +1,6 @@
 ---
-"@ensembleui/react-kitchen-sink": minor
-"@ensembleui/react-runtime": minor
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
 ---
 
 Added 3 header styles to the Collapsible widget: textColor, borderColor, and borderWidth.Added 3 header styles: textColor, borderColor, and borderWidth.

--- a/.changeset/short-pens-flash.md
+++ b/.changeset/short-pens-flash.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": minor
+"@ensembleui/react-runtime": minor
+---
+
+Added 3 header styles to the Collapsible widget: textColor, borderColor, and borderWidth.Added 3 header styles: textColor, borderColor, and borderWidth.

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -1,4 +1,6 @@
 View:
+  styles:
+    scrollableView: true
   onLoad:
     executeCode:
       body: |-
@@ -71,6 +73,43 @@ View:
                     color: yellow
               - Avatar:
                   name: "  4Dr.  cabin4  i  "
+        - Card: 
+            styles:
+              maxWidth: unset
+              width: unset
+              gap: 10px
+            children:
+              - Text:
+                  styles:
+                    names: heading-3
+                  text: Collapsible Testing
+              - Collapsible:
+                  headerStyle:
+                    headerBg: "black"
+                    textColor: "#5DCDC8"
+                  contentStyle:
+                    contentBg: "black"
+                  expandIcon: 
+                    name: Remove
+                    color: white
+                  collpaseIcon: 
+                    name: Add
+                    color: white
+                  items:
+                    - key: "2"
+                      label: What house is Harry Potter in?
+                      children:
+                        Text:
+                          styles:
+                            color: white
+                          text: Harry Potter is in Gryffindor.
+                    - key: "3"
+                      label: Who is the half blood prince?
+                      children:
+                        Text:
+                          styles:
+                            color: white
+                          text: The half blood prince is Severus Snape.
         - Lottie:
             id: MyLottie
             source: https://lottie.host/3568da34-6083-42fc-a254-74d9c1e15b2f/wcVmO2igxm.json

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -603,7 +603,7 @@ View:
                   expandIcon: 
                     name: Remove
                     color: white
-                  collpaseIcon: 
+                  collapseIcon: 
                     name: Add
                     color: white
                   items:

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -87,6 +87,8 @@ View:
                   headerStyle:
                     headerBg: "black"
                     textColor: "#5DCDC8"
+                    borderColor: "#5DCDC8"
+                    borderWidth: 2
                   contentStyle:
                     contentBg: "black"
                   expandIcon: 
@@ -96,13 +98,20 @@ View:
                     name: Add
                     color: white
                   items:
-                    - key: "2"
+                    - key: "1"
                       label: What house is Harry Potter in?
                       children:
                         Text:
                           styles:
                             color: white
                           text: Harry Potter is in Gryffindor.
+                    - key: "2"
+                      label: Which subject does Professor Flitwick teach?
+                      children:
+                        Text:
+                          styles:
+                            color: white
+                          text: Professor Flitwick teaches Charms.
                     - key: "3"
                       label: Who is the half blood prince?
                       children:

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -73,52 +73,7 @@ View:
                     color: yellow
               - Avatar:
                   name: "  4Dr.  cabin4  i  "
-        - Card: 
-            styles:
-              maxWidth: unset
-              width: unset
-              gap: 10px
-            children:
-              - Text:
-                  styles:
-                    names: heading-3
-                  text: Collapsible Testing
-              - Collapsible:
-                  headerStyle:
-                    headerBg: "black"
-                    textColor: "#5DCDC8"
-                    borderColor: "#5DCDC8"
-                    borderWidth: 2
-                  contentStyle:
-                    contentBg: "black"
-                  expandIcon: 
-                    name: Remove
-                    color: white
-                  collpaseIcon: 
-                    name: Add
-                    color: white
-                  items:
-                    - key: "1"
-                      label: What house is Harry Potter in?
-                      children:
-                        Text:
-                          styles:
-                            color: white
-                          text: Harry Potter is in Gryffindor.
-                    - key: "2"
-                      label: Which subject does Professor Flitwick teach?
-                      children:
-                        Text:
-                          styles:
-                            color: white
-                          text: Professor Flitwick teaches Charms.
-                    - key: "3"
-                      label: Who is the half blood prince?
-                      children:
-                        Text:
-                          styles:
-                            color: white
-                          text: The half blood prince is Severus Snape.
+        
         - Lottie:
             id: MyLottie
             source: https://lottie.host/3568da34-6083-42fc-a254-74d9c1e15b2f/wcVmO2igxm.json
@@ -627,6 +582,52 @@ View:
                     color: ${colors.primary['600']}
                     thickness: 4
                     backgroundColor: ${colors.light['200']}
+        - Card: 
+            styles:
+              maxWidth: unset
+              width: unset
+              gap: 10px
+            children:
+              - Text:
+                  styles:
+                    names: heading-3
+                  text: Collapsible Testing
+              - Collapsible:
+                  headerStyle:
+                    headerBg: "black"
+                    textColor: "#5DCDC8"
+                    borderColor: "#5DCDC8"
+                    borderWidth: 2
+                  contentStyle:
+                    contentBg: "black"
+                  expandIcon: 
+                    name: Remove
+                    color: white
+                  collpaseIcon: 
+                    name: Add
+                    color: white
+                  items:
+                    - key: "1"
+                      label: What house is Harry Potter in?
+                      children:
+                        Text:
+                          styles:
+                            color: white
+                          text: Harry Potter is in Gryffindor.
+                    - key: "2"
+                      label: Which subject does Professor Flitwick teach?
+                      children:
+                        Text:
+                          styles:
+                            color: white
+                          text: Professor Flitwick teaches Charms.
+                    - key: "3"
+                      label: Who is the half blood prince?
+                      children:
+                        Text:
+                          styles:
+                            color: white
+                          text: The half blood prince is Severus Snape.
         - Card:
             styles:
               maxWidth: unset

--- a/packages/runtime/src/widgets/Collapsible.tsx
+++ b/packages/runtime/src/widgets/Collapsible.tsx
@@ -33,6 +33,7 @@ interface CollapsibleItem {
 interface CollapsibleHeaderStyles {
   headerBg?: string;
   headerPadding?: undefined | string | number;
+  textColor?: string;
 }
 
 interface CollapsibleContentStyles {
@@ -183,15 +184,33 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
     onCallapseActionCallback(value);
   };
 
+  // Since the textColor may be in the headerStyle, we need to extract it if it exists
+  const getHeaderStyles = (headerStyle: CollapsibleHeaderStyles | undefined) => {
+    if (typeof headerStyle === 'undefined') return {};
+    if (headerStyle.textColor) 
+      return { 
+        ...(headerStyle.headerBg ? { headerBg: headerStyle.headerBg } : {}), 
+        ...(headerStyle.headerPadding ? { headerPadding: headerStyle.headerPadding } : {})
+      };
+    return headerStyle;
+  };
+
+  // Retrieves the colorText for the heading if it exists
+  const getColorTextHeading = (textColor: string | undefined) => {
+    if (typeof textColor === 'undefined') return {};
+    return { colorTextHeading: textColor };
+  }
+  
   return (
     <ConfigProvider
       theme={{
         components: {
           Collapse: {
-            ...values?.headerStyle,
+            ...getHeaderStyles(values?.headerStyle),
             ...values?.contentStyle,
           },
         },
+        token: getColorTextHeading(values?.headerStyle?.textColor),
       }}
     >
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}

--- a/packages/runtime/src/widgets/Collapsible.tsx
+++ b/packages/runtime/src/widgets/Collapsible.tsx
@@ -31,9 +31,11 @@ interface CollapsibleItem {
 }
 
 interface CollapsibleHeaderStyles {
-  headerBg?: string;
-  headerPadding?: undefined | string | number;
-  textColor?: string;
+  headerBg?: string;                              // The background color of the header
+  headerPadding?: undefined | string | number;    // The padding of the header
+  textColor?: string;                             // The color of the text in the header
+  borderColor?: string;                           // The color of the border
+  borderWidth?: number;                           // The width of the border line
 }
 
 interface CollapsibleContentStyles {
@@ -42,15 +44,15 @@ interface CollapsibleContentStyles {
 }
 
 export type CollapsibleProps = {
-  items?: CollapsibleItem[];
-  expandIconPosition?: "start" | "end";
-  value: Expression<string>[];
-  onCollapse?: EnsembleAction;
-  isAccordion?: boolean;
-  collpaseIcon?: IconProps;
-  expandIcon?: IconProps;
-  headerStyle?: CollapsibleHeaderStyles;
-  contentStyle?: CollapsibleContentStyles;
+  items?: CollapsibleItem[];                // The items to be displayed in the Collapsible widget
+  expandIconPosition?: "start" | "end";     // The position of the expand icon (either "start" or "end")
+  value: Expression<string>[];             
+  onCollapse?: EnsembleAction;              // Perform an action when the Collapsible widget is collapsed
+  isAccordion?: boolean;                    // If true, only one panel can be expanded at a time
+  collpaseIcon?: IconProps;                 // The Icon displayed when the Collapsible widget is collapsed
+  expandIcon?: IconProps;                   // The Icon displayed when the Collapsible widget is expanded
+  headerStyle?: CollapsibleHeaderStyles;    // Add one of the following 5 styles to the header: headerBg, headerPadding, textColor, borderColor, borderWidth
+  contentStyle?: CollapsibleContentStyles;  // Add one of the following 2 styles to the content of the Collapsible widget: contentBg, contentPadding
 } & EnsembleWidgetProps &
   HasItemTemplate;
 
@@ -184,22 +186,17 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
     onCallapseActionCallback(value);
   };
 
-  // Since the textColor may be in the headerStyle, we need to extract it if it exists
+  // Since I did not like the default names of the properties in the ant design Collapse component, 
+  // I changed them to more meaningful names, and this means I need to rename the keys.
   const getHeaderStyles = (headerStyle: CollapsibleHeaderStyles | undefined) => {
     if (typeof headerStyle === 'undefined') return {};
-    if (headerStyle.textColor) 
-      return { 
-        ...(headerStyle.headerBg ? { headerBg: headerStyle.headerBg } : {}), 
-        ...(headerStyle.headerPadding ? { headerPadding: headerStyle.headerPadding } : {})
-      };
-    return headerStyle;
+    return Object.keys(headerStyle).reduce<CollapsibleHeaderStyles>((prev, key) => {
+      if (key === 'textColor') return {...prev, colorTextHeading: headerStyle[key]};
+      if (key === 'borderColor') return {...prev, colorBorder: headerStyle[key]};
+      if (key === 'borderWidth') return {...prev, lineWidth: headerStyle[key]};
+      return {...prev, [key]: headerStyle[key as keyof CollapsibleHeaderStyles]};
+    }, {});
   };
-
-  // Retrieves the colorText for the heading if it exists
-  const getColorTextHeading = (textColor: string | undefined) => {
-    if (typeof textColor === 'undefined') return {};
-    return { colorTextHeading: textColor };
-  }
   
   return (
     <ConfigProvider
@@ -208,9 +205,8 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
           Collapse: {
             ...getHeaderStyles(values?.headerStyle),
             ...values?.contentStyle,
-          },
+          }
         },
-        token: getColorTextHeading(values?.headerStyle?.textColor),
       }}
     >
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}

--- a/packages/runtime/src/widgets/Collapsible.tsx
+++ b/packages/runtime/src/widgets/Collapsible.tsx
@@ -11,7 +11,7 @@ import {
   defaultScreenContext,
 } from "@ensembleui/react-framework";
 import { Collapse, type CollapseProps, ConfigProvider } from "antd";
-import { get, isArray, isEmpty, isObject, isString } from "lodash-es";
+import { get, isArray, isEmpty, isObject, isString, mapKeys } from "lodash-es";
 import type {
   EnsembleWidgetProps,
   HasItemTemplate,
@@ -31,11 +31,16 @@ interface CollapsibleItem {
 }
 
 interface CollapsibleHeaderStyles {
-  headerBg?: string; // The background color of the header
-  headerPadding?: undefined | string | number; // The padding of the header
-  textColor?: string; // The color of the text in the header
-  borderColor?: string; // The color of the border
-  borderWidth?: number; // The width of the border line
+  /** The background color of the header */
+  headerBg?: string;
+  /** The padding of the header */
+  headerPadding?: undefined | string | number;
+  /** The color of the text in the header */
+  textColor?: string;
+  /** The color of the border */
+  borderColor?: string;
+  /** The width of the border line */
+  borderWidth?: number;
 }
 
 interface CollapsibleContentStyles {
@@ -44,15 +49,23 @@ interface CollapsibleContentStyles {
 }
 
 export type CollapsibleProps = {
-  items?: CollapsibleItem[]; // The items to be displayed in the Collapsible widget
-  expandIconPosition?: "start" | "end"; // The position of the expand icon (either "start" or "end")
+  /** The items to be displayed in the Collapsible widget */
+  items?: CollapsibleItem[];
+  /** The position of the expand icon (either "start" or "end") */
+  expandIconPosition?: "start" | "end";
   value: Expression<string>[];
-  onCollapse?: EnsembleAction; // Perform an action when the Collapsible widget is collapsed
-  isAccordion?: boolean; // If true, only one panel can be expanded at a time
-  collpaseIcon?: IconProps; // The Icon displayed when the Collapsible widget is collapsed
-  expandIcon?: IconProps; // The Icon displayed when the Collapsible widget is expanded
-  headerStyle?: CollapsibleHeaderStyles; // Add one of the following 5 styles to the header: headerBg, headerPadding, textColor, borderColor, borderWidth
-  contentStyle?: CollapsibleContentStyles; // Add one of the following 2 styles to the content of the Collapsible widget: contentBg, contentPadding
+  /** Perform an action when the Collapsible widget is collapsed */
+  onCollapse?: EnsembleAction;
+  /** If true, only one panel can be expanded at a time */
+  isAccordion?: boolean;
+  /** The Icon displayed when the Collapsible widget is collapsed */
+  collapseIcon?: IconProps;
+  /** The Icon displayed when the Collapsible widget is expanded */
+  expandIcon?: IconProps;
+  /** Add one of the following 5 styles to the header: headerBg, headerPadding, textColor, borderColor, borderWidth */
+  headerStyle?: CollapsibleHeaderStyles;
+  /** Add one of the following 2 styles to the content of the Collapsible widget: contentBg, contentPadding */
+  contentStyle?: CollapsibleContentStyles;
 } & EnsembleWidgetProps &
   HasItemTemplate;
 
@@ -153,7 +166,7 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
     const iconName = isActive
       ? "default_collapsed_icon"
       : "default_expand_icon";
-    const iconProps = isActive ? values?.expandIcon : values?.collpaseIcon;
+    const iconProps = isActive ? values?.expandIcon : values?.collapseIcon;
 
     return (
       <Icon
@@ -190,21 +203,12 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
     headerStyle: CollapsibleHeaderStyles | undefined,
   ): CollapsibleHeaderStyles => {
     if (typeof headerStyle === "undefined") return {};
-    return Object.keys(headerStyle).reduce<CollapsibleHeaderStyles>(
-      (prev, key) => {
-        if (key === "textColor")
-          return { ...prev, colorTextHeading: headerStyle[key] };
-        if (key === "borderColor")
-          return { ...prev, colorBorder: headerStyle[key] };
-        if (key === "borderWidth")
-          return { ...prev, lineWidth: headerStyle[key] };
-        return {
-          ...prev,
-          [key]: headerStyle[key as keyof CollapsibleHeaderStyles],
-        };
-      },
-      {},
-    );
+    return mapKeys(headerStyle, (_, key) => {
+      if (key === "textColor") return "colorTextHeading";
+      if (key === "borderColor") return "colorBorder";
+      if (key === "borderWidth") return "lineWidth";
+      return key;
+    });
   };
 
   return (

--- a/packages/runtime/src/widgets/Collapsible.tsx
+++ b/packages/runtime/src/widgets/Collapsible.tsx
@@ -26,16 +26,16 @@ const widgetName = "Collapsible";
 
 interface CollapsibleItem {
   key: Expression<string>;
-  label: Expression<string> | Record<string, unknown>;
-  children: Expression<string> | Record<string, unknown>;
+  label: Expression<string> | { [key: string]: unknown };
+  children: Expression<string> | { [key: string]: unknown };
 }
 
 interface CollapsibleHeaderStyles {
-  headerBg?: string;                              // The background color of the header
-  headerPadding?: undefined | string | number;    // The padding of the header
-  textColor?: string;                             // The color of the text in the header
-  borderColor?: string;                           // The color of the border
-  borderWidth?: number;                           // The width of the border line
+  headerBg?: string; // The background color of the header
+  headerPadding?: undefined | string | number; // The padding of the header
+  textColor?: string; // The color of the text in the header
+  borderColor?: string; // The color of the border
+  borderWidth?: number; // The width of the border line
 }
 
 interface CollapsibleContentStyles {
@@ -44,15 +44,15 @@ interface CollapsibleContentStyles {
 }
 
 export type CollapsibleProps = {
-  items?: CollapsibleItem[];                // The items to be displayed in the Collapsible widget
-  expandIconPosition?: "start" | "end";     // The position of the expand icon (either "start" or "end")
-  value: Expression<string>[];             
-  onCollapse?: EnsembleAction;              // Perform an action when the Collapsible widget is collapsed
-  isAccordion?: boolean;                    // If true, only one panel can be expanded at a time
-  collpaseIcon?: IconProps;                 // The Icon displayed when the Collapsible widget is collapsed
-  expandIcon?: IconProps;                   // The Icon displayed when the Collapsible widget is expanded
-  headerStyle?: CollapsibleHeaderStyles;    // Add one of the following 5 styles to the header: headerBg, headerPadding, textColor, borderColor, borderWidth
-  contentStyle?: CollapsibleContentStyles;  // Add one of the following 2 styles to the content of the Collapsible widget: contentBg, contentPadding
+  items?: CollapsibleItem[]; // The items to be displayed in the Collapsible widget
+  expandIconPosition?: "start" | "end"; // The position of the expand icon (either "start" or "end")
+  value: Expression<string>[];
+  onCollapse?: EnsembleAction; // Perform an action when the Collapsible widget is collapsed
+  isAccordion?: boolean; // If true, only one panel can be expanded at a time
+  collpaseIcon?: IconProps; // The Icon displayed when the Collapsible widget is collapsed
+  expandIcon?: IconProps; // The Icon displayed when the Collapsible widget is expanded
+  headerStyle?: CollapsibleHeaderStyles; // Add one of the following 5 styles to the header: headerBg, headerPadding, textColor, borderColor, borderWidth
+  contentStyle?: CollapsibleContentStyles; // Add one of the following 2 styles to the content of the Collapsible widget: contentBg, contentPadding
 } & EnsembleWidgetProps &
   HasItemTemplate;
 
@@ -116,10 +116,9 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
             <CustomScopeProvider value={item as CustomScope}>
               {EnsembleRuntime.render([
                 unwrapWidget(
-                  itemTemplate.template.properties.label as Record<
-                    string,
-                    unknown
-                  >,
+                  itemTemplate.template.properties.label as {
+                    [key: string]: unknown;
+                  },
                 ),
               ])}
             </CustomScopeProvider>
@@ -130,10 +129,9 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
             <CustomScopeProvider value={item as CustomScope}>
               {EnsembleRuntime.render([
                 unwrapWidget(
-                  itemTemplate.template.properties.children as Record<
-                    string,
-                    unknown
-                  >,
+                  itemTemplate.template.properties.children as {
+                    [key: string]: unknown;
+                  },
                 ),
               ])}
             </CustomScopeProvider>
@@ -186,18 +184,29 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
     onCallapseActionCallback(value);
   };
 
-  // Since I did not like the default names of the properties in the ant design Collapse component, 
+  // Since I did not like the default names of the properties in the ant design Collapse component,
   // I changed them to more meaningful names, and this means I need to rename the keys.
-  const getHeaderStyles = (headerStyle: CollapsibleHeaderStyles | undefined) => {
-    if (typeof headerStyle === 'undefined') return {};
-    return Object.keys(headerStyle).reduce<CollapsibleHeaderStyles>((prev, key) => {
-      if (key === 'textColor') return {...prev, colorTextHeading: headerStyle[key]};
-      if (key === 'borderColor') return {...prev, colorBorder: headerStyle[key]};
-      if (key === 'borderWidth') return {...prev, lineWidth: headerStyle[key]};
-      return {...prev, [key]: headerStyle[key as keyof CollapsibleHeaderStyles]};
-    }, {});
+  const getHeaderStyles = (
+    headerStyle: CollapsibleHeaderStyles | undefined,
+  ): CollapsibleHeaderStyles => {
+    if (typeof headerStyle === "undefined") return {};
+    return Object.keys(headerStyle).reduce<CollapsibleHeaderStyles>(
+      (prev, key) => {
+        if (key === "textColor")
+          return { ...prev, colorTextHeading: headerStyle[key] };
+        if (key === "borderColor")
+          return { ...prev, colorBorder: headerStyle[key] };
+        if (key === "borderWidth")
+          return { ...prev, lineWidth: headerStyle[key] };
+        return {
+          ...prev,
+          [key]: headerStyle[key as keyof CollapsibleHeaderStyles],
+        };
+      },
+      {},
+    );
   };
-  
+
   return (
     <ConfigProvider
       theme={{
@@ -205,7 +214,7 @@ export const Collapsible: React.FC<CollapsibleProps> = (props) => {
           Collapse: {
             ...getHeaderStyles(values?.headerStyle),
             ...values?.contentStyle,
-          }
+          },
         },
       }}
     >


### PR DESCRIPTION
## Describe your changes
Added 3 header styles to the Collapsible widget: textColor, borderColor, and borderWidth. Also created a getHeaderStyles function that renames some of the header styles as I did not like the default names that Ant Design gave to them.

## Issue ticket number and link
[Issue #692
](https://github.com/EnsembleUI/ensemble-react/issues/692)

Closes #692 

## Checklist before requesting a review
- [ ✅] I have performed a self-review of my code
- [ ✅] I have added tests
- [ ✅] I have added a changeset `pnpm changeset add`
- [ ✅] I have added example usage in the kitchen sink app
