### PR TITLE
fix: don't route when page/url is not given in menu

### DIFF
--- a/.changeset/lazy-snails-sniff.md
+++ b/.changeset/lazy-snails-sniff.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+don't route when page/url is not given in menu

--- a/apps/kitchen-sink/src/ensemble/screens/menu.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/menu.yaml
@@ -74,6 +74,28 @@ ViewGroup:
       - label: Hidden Page
         icon: HelpOutlineOutlined
         visible: false
+      - customItem:
+          widget:
+            Button:
+              label: Docs
+              styles:
+                width: 100%
+                textColor: aqua
+                fontWeight: bold
+                backgroundColor: purple
+              onTap:
+                showDialog:
+                  widget:
+                    Column:
+                      children:
+                        - TextInput:
+                            label: Enter your name
+                        - Button:
+                            label: Lets go!
+                            onTap:
+                              navigateExternalScreen:
+                                url: https://docs.ensembleui.com/
+                                openNewTab: true
     footer:
       Row:
         styles:

--- a/packages/runtime/src/runtime/entry.tsx
+++ b/packages/runtime/src/runtime/entry.tsx
@@ -52,7 +52,6 @@ export const EnsembleEntry: React.FC<EnsembleEntryProps> = ({
     return (
       <div style={{ display: "flex", flexDirection: "row" }}>
         <SideBarMenu
-          enableSearch={false}
           footer={entry.footer}
           header={entry.header}
           id={entry.id}


### PR DESCRIPTION
## Describe your changes
1. don't route when page/url is not given in menu
2. revert back exposed method from `setIsCollapsed` to `setCollapsed` which got added [here](https://github.com/EnsembleUI/ensemble-react/pull/744/files#diff-698b21689b3e129055e1704ea4e6aa532839d68b2a24af0cffa1f1adc5136379R101)
3. remove unused `enableSearch` prop
4. make `icon` prop optional

### Screenshots [Optional]

https://github.com/user-attachments/assets/56831c4f-feab-4e10-bd33-3cb81239d4f6


## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
