### PR TITLE
Use unique key when applying styles to modal

### DIFF
--- a/.changeset/sharp-mugs-yawn.md
+++ b/.changeset/sharp-mugs-yawn.md
@@ -1,0 +1,7 @@
+---
+"@ensembleui/react-framework": patch
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+use unique key when applying styles to modal

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -25,6 +25,23 @@ View:
       styles:
         names: page
       children:
+        - Button:
+            label: open another modal screen
+            onTap:
+              navigateModalScreen:
+                name: widgets
+                height: 200px
+                width: 900px
+        - Button:
+            label: show dialog
+            onTap:
+              showDialog:
+                widget:
+                  Text:
+                    text: i am a text
+                options:
+                  height: 50px
+                  width: 80px
         - Icon:
         - Text:
             styles:

--- a/packages/framework/src/hooks/useWidgetId.ts
+++ b/packages/framework/src/hooks/useWidgetId.ts
@@ -45,7 +45,7 @@ const JS_ID_REGEX = /^[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*$/;
 
 const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
-const generateRandomString = (length: number): string => {
+export const generateRandomString = (length: number): string => {
   let randomString = "";
 
   for (let i = 0; i < length; i++) {

--- a/packages/runtime/src/runtime/modal/index.tsx
+++ b/packages/runtime/src/runtime/modal/index.tsx
@@ -14,7 +14,7 @@ import { createPortal } from "react-dom";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
 import CloseFullscreenIcon from "@mui/icons-material/CloseFullscreen";
 import { CloseOutlined } from "@ant-design/icons";
-import { useEvaluate } from "@ensembleui/react-framework";
+import { generateRandomString, useEvaluate } from "@ensembleui/react-framework";
 import { isEmpty, isString, omit, pick } from "lodash-es";
 import { useNavigate } from "react-router-dom";
 import { getComponentStyles } from "../../shared/styles";
@@ -57,7 +57,7 @@ interface ModalState {
   visible: boolean;
   content: React.ReactNode;
   options: ModalProps;
-  key: number;
+  key: string;
   isDialog: boolean;
 }
 
@@ -116,9 +116,7 @@ export const ModalWrapper: React.FC<PropsWithChildren> = ({ children }) => {
           visible: true,
           content: newModal?.content,
           options: evaluatedOptions,
-          key: oldModalState.length
-            ? oldModalState[oldModalState.length - 1].key + 1
-            : 0,
+          key: generateRandomString(10),
           isDialog: Boolean(newModal?.isDialog),
         },
       ]);
@@ -293,16 +291,16 @@ export const ModalWrapper: React.FC<PropsWithChildren> = ({ children }) => {
         if (!modal.visible) {
           return null;
         }
-        const { options } = modal;
+        const { options, key } = modal;
         const modalContent = (
           <>
-            <style>{getCustomStyles(options, index)}</style>
+            <style>{getCustomStyles(options, key)}</style>
             {Boolean(isFullScreen[index]) && (
-              <style>{getFullScreenStyles(index)}</style>
+              <style>{getFullScreenStyles(key)}</style>
             )}
             <Modal
               centered={!isFullScreen[index]}
-              className={`ensemble-modal-${index}`}
+              className={`ensemble-modal-${key}`}
               closable={false}
               footer={null}
               key={modal.key}

--- a/packages/runtime/src/runtime/modal/utils.ts
+++ b/packages/runtime/src/runtime/modal/utils.ts
@@ -2,19 +2,19 @@ import { omit } from "lodash-es";
 import { getComponentStyles } from "../../shared/styles";
 import type { ModalProps } from ".";
 
-export const getCustomStyles = (options: ModalProps, index: number): string =>
+export const getCustomStyles = (options: ModalProps, key: string): string =>
   `
     .ant-modal-root .ant-modal-centered .ant-modal {
       top: unset;
     }
-    .ensemble-modal-${index} {
+    .ensemble-modal-${key} {
       max-height: 100vh;
       max-width: 100vw;
     }
-    .ensemble-modal-${index} > div {
+    .ensemble-modal-${key} > div {
       height: ${options.height || "auto"};
     }
-    .ensemble-modal-${index} .ant-modal-content {
+    .ensemble-modal-${key} .ant-modal-content {
       display: flex;
       flex-direction: column;
       ${
@@ -32,14 +32,14 @@ export const getCustomStyles = (options: ModalProps, index: number): string =>
       }
       ${options.showShadow === false ? "box-shadow: none !important;" : ""}
     }
-    .ensemble-modal-${index} .ant-modal-body {
+    .ensemble-modal-${key} .ant-modal-body {
       height: 100%;
       overflow-y: auto;
     }
   `;
 
-export const getFullScreenStyles = (index: number): string => `
-  .ensemble-modal-${index} .ant-modal-content {
+export const getFullScreenStyles = (key: string): string => `
+  .ensemble-modal-${key} .ant-modal-content {
     height: 100vh;
     width: 100vw;
     margin: 0;


### PR DESCRIPTION
## Describe your changes
problem: when a dialog/modal screen is opened from within a modal screen, the styles of top most dialog/modal are being used in existing ones too.

### Screenshots [Optional]

https://github.com/user-attachments/assets/c30b2b70-d506-478a-99de-1faba465a69b


https://github.com/user-attachments/assets/ba909433-cd24-40d4-9af6-f8c8a222d286


## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
