### PR TITLE
fix TextInput's regex validator not validating on no input

### DIFF
--- a/.changeset/many-days-sip.md
+++ b/.changeset/many-days-sip.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+fix TextInput's regex validator not validating on no input

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -133,8 +133,8 @@ View:
                     - TextInput:
                         id: regexTextInput
                         validator:
-                          regex: "[0-5]"
-                          regexError: "Only numbers 0 to 5 are allowed"
+                          regex: .{1,}
+                          regexError: "write something atleast"
                         label: Text input with regex
                     - MultiSelect:
                         id: multiselectoptions1

--- a/packages/runtime/src/widgets/Form/TextInput.tsx
+++ b/packages/runtime/src/widgets/Form/TextInput.tsx
@@ -145,9 +145,10 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
 
     if (values?.validator?.regex) {
       rulesArray.push({
-        validator: (_, inputValue: string) => {
+        validator: (_, inputValue?: string) => {
           if (
-            new RegExp(values.validator?.regex || "").test(inputValue || "")
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            new RegExp(values.validator!.regex || "").test(inputValue || "")
           ) {
             return;
           }

--- a/packages/runtime/src/widgets/Form/TextInput.tsx
+++ b/packages/runtime/src/widgets/Form/TextInput.tsx
@@ -143,13 +143,11 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
       });
     }
 
-    if (values?.validator?.regex) {
+    const regex = values?.validator?.regex;
+    if (regex) {
       rulesArray.push({
         validator: (_, inputValue?: string) => {
-          if (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            new RegExp(values.validator!.regex || "").test(inputValue || "")
-          ) {
+          if (new RegExp(regex).test(inputValue || "")) {
             return;
           }
           return Promise.reject(

--- a/packages/runtime/src/widgets/Form/TextInput.tsx
+++ b/packages/runtime/src/widgets/Form/TextInput.tsx
@@ -145,8 +145,18 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
 
     if (values?.validator?.regex) {
       rulesArray.push({
-        pattern: new RegExp(values.validator.regex),
-        message: values.validator.regexError || "The field has invalid value",
+        validator: (_, inputValue: string) => {
+          if (
+            new RegExp(values.validator?.regex || "").test(inputValue || "")
+          ) {
+            return;
+          }
+          return Promise.reject(
+            new Error(
+              values.validator?.regexError || "The field has an invalid value",
+            ),
+          );
+        },
       });
     }
 
@@ -158,7 +168,14 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     }
 
     return rulesArray;
-  }, [values?.validator, values?.mask]);
+  }, [
+    values?.validator?.minLength,
+    values?.validator?.maxLength,
+    values?.validator?.regex,
+    values?.validator?.regexError,
+    values?.mask,
+    patternValue,
+  ]);
 
   return (
     <EnsembleFormItem rules={rules} valuePropName="value" values={values}>


### PR DESCRIPTION
## Describe your changes

**Problem:**
regex: `.{1,}` does not work for "atleast 1 character" when there's no input entered by user - and form is submitted.

**Solution:**
when there's no input entered by user, treat `undefined` value of TextInput as empty string so that regex can be validated successfully.

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
