### PR TITLE
fix: choose first theme as default from the theme yaml and add theme in charts

### DIFF
--- a/.changeset/funny-cobras-approve.md
+++ b/.changeset/funny-cobras-approve.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-framework": patch
+---
+
+fix: choose first theme as default from the theme yaml

--- a/packages/framework/src/hooks/useApplicationContext.tsx
+++ b/packages/framework/src/hooks/useApplicationContext.tsx
@@ -68,9 +68,7 @@ const HydrateAtoms: React.FC<
     appContext: ApplicationContextDefinition;
   }>
 > = ({ appContext, children }) => {
-  const themeValue = useAtomValue(themeAtom);
-  const activeThemeName =
-    themeValue.name || keys(appContext.application?.themes)[0];
+  const activeThemeName = keys(appContext.application?.themes)[0];
 
   const activeTheme =
     appContext.application?.themes[activeThemeName] || defaultThemeDefinition;

--- a/packages/runtime/src/widgets/Charts/index.tsx
+++ b/packages/runtime/src/widgets/Charts/index.tsx
@@ -25,9 +25,10 @@ import {
   useApplicationContext,
   createEvaluationContext,
   useCustomScope,
+  useThemeScope,
 } from "@ensembleui/react-framework";
 import { Alert } from "antd";
-import { isEqualWith } from "lodash-es";
+import { isEqualWith, merge } from "lodash-es";
 import { WidgetRegistry } from "../../registry";
 import type { EnsembleWidgetProps } from "../../shared/types";
 import { BarChart } from "./BarChart";
@@ -87,6 +88,7 @@ const CONFIG_EVAL_EXPIRY = 5000;
 export const Chart: React.FC<ChartProps> = (props) => {
   const screenContext = useScreenContext();
   const applicationContext = useApplicationContext();
+  const { theme } = useThemeScope();
   const parentScope = useCustomScope();
   const storage = useEnsembleStorage();
   const { resolvedWidgetId, resolvedTestId } = useWidgetId(props.id);
@@ -109,7 +111,9 @@ export const Chart: React.FC<ChartProps> = (props) => {
         // eslint-disable-next-line prefer-named-capture-group
         props.config?.toString()?.replace(/['"]\$\{([^}]*)\}['"]/g, "$1"), // replace "${...}" or '${...}' with ...
         createEvaluationContext({
-          applicationContext: applicationContext ?? {},
+          applicationContext: merge({}, applicationContext, {
+            selectedTheme: theme,
+          }),
           screenContext: screenContext ?? {},
           ensemble: {
             storage,


### PR DESCRIPTION
## Describe your changes
load first theme as default from theme yaml

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
