### PR TITLE
Refactor useExecuteCode to leverage atomCallback

### DIFF
--- a/.changeset/chatty-icons-burn.md
+++ b/.changeset/chatty-icons-burn.md
@@ -1,0 +1,7 @@
+---
+"@ensembleui/react-framework": patch
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+Optimize dependencies for useExecuteCode

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -7,6 +7,7 @@ View:
         ensemble.storage.set('inputVal', 'sagar');
         ensemble.storage.set('mockApiStatusCode', 200);
         ensemble.storage.set('mockApiReasonPhrase', 'Success!');
+        ensemble.storage.set('mockApiName', 'testMockResponse');
         ensemble.storage.set('dummyData', [
           { value: "val 1", label: "lab 1" },
           { value: "val 2", label: "lab 2" },
@@ -365,6 +366,7 @@ View:
                   initialValue: false
                   onChange:
                     executeCode: |
+                      debugger;
                       app.setUseMockResponse(!app.useMockResponse);
               - Checkbox:
                   id: throwMockApiErrorCheckbox
@@ -386,7 +388,7 @@ View:
                   label: Call API!
                   onTap:
                     invokeAPI:
-                      name: testMockResponse
+                      name: ${ensemble.storage.get('mockApiName')}
                       onResponse:
                         executeCode: console.log("Mock API called ", response);
               - Button:
@@ -395,7 +397,7 @@ View:
                   label: Call API from executeCode!
                   onTap:
                     executeCode: |
-                      ensemble.invokeAPI("testMockResponse");
+                      ensemble.invokeAPI(ensemble.storage.get('mockApiName'));
               - Spacer:
                   styles:
                     size: 20
@@ -455,7 +457,7 @@ API:
     uri: https://dummyjson.com/users/1
     mockResponse:
       statusCode: "${ensemble.storage.get('mockApiStatusCode')}"
-      reasonPhrase: "${ensemble.storage.get('mockApiReasonPhrase')}"
+      reasonPhrase: "${ensemble.env.randomId}"
       body:
         - id: 0
           name: Harry Potter

--- a/apps/kitchen-sink/src/ensemble/widgets/StyledText.yaml
+++ b/apps/kitchen-sink/src/ensemble/widgets/StyledText.yaml
@@ -4,11 +4,16 @@ Widget:
       console.log('StyledText Widget loaded');
       console.log(inputText);
   body:
-    Text:
-      text: Styled Text
-      styles:
-        fontSize: 24px
-        fontWeight: ${typography.fontWeight['bold']}
-        color: blue
-        backgroundColor: ${colors.dark['300']}
-        padding: 8px
+    Column:
+      onTap:
+        executeCode: |
+          console.log(inputText)
+      children:
+        - Text:
+            text: Styled Text
+            styles:
+              fontSize: 24px
+              fontWeight: ${typography.fontWeight['bold']}
+              color: blue
+              backgroundColor: ${colors.dark['300']}
+              padding: 8px

--- a/packages/framework/src/api/data.ts
+++ b/packages/framework/src/api/data.ts
@@ -46,7 +46,10 @@ export const invokeAPI = async (
     api,
     { ...apiInputs, ...context },
     {
-      mockResponse: mockResponse(evaluatedMockResponse, useMockResponse),
+      mockResponse: mockResponse(
+        evaluatedMockResponse ?? api.mockResponse,
+        useMockResponse,
+      ),
       useMockResponse,
     },
   );

--- a/packages/framework/src/api/data.ts
+++ b/packages/framework/src/api/data.ts
@@ -1,0 +1,151 @@
+import { has, set } from "lodash-es";
+import type { Setter } from "jotai";
+import { DataFetcher, type WebSocketConnection, type Response } from "../data";
+import { error } from "../shared";
+import type {
+  EnsembleActionHookResult,
+  EnsembleMockResponse,
+  EnsembleSocketModel,
+} from "../shared";
+import { screenDataAtom, type ScreenContextDefinition } from "../state";
+import { isUsingMockResponse } from "../appConfig";
+import { mockResponse } from "../evaluate/mock";
+
+export const invokeAPI = async (
+  apiName: string,
+  screenContext: ScreenContextDefinition,
+  apiInputs?: { [key: string]: unknown },
+  context?: { [key: string]: unknown },
+  evaluatedMockResponse?: string | EnsembleMockResponse,
+  setter?: Setter,
+): Promise<Response | undefined> => {
+  const api = screenContext.model?.apis?.find(
+    (model) => model.name === apiName,
+  );
+
+  if (!api) {
+    error(`Unable to find API with name ${apiName}`);
+    return;
+  }
+
+  const update = {};
+  if (setter) {
+    // Now, because the API exists, set its state to loading
+    set(update, api.name, {
+      isLoading: true,
+      isError: false,
+      isSuccess: false,
+    });
+    setter(screenDataAtom, update);
+  }
+
+  // If mock resposne does not exist, fetch the data directly from the API
+  const useMockResponse =
+    has(api, "mockResponse") && isUsingMockResponse(screenContext.app?.id);
+  const res = await DataFetcher.fetch(
+    api,
+    { ...apiInputs, ...context },
+    {
+      mockResponse: mockResponse(evaluatedMockResponse, useMockResponse),
+      useMockResponse,
+    },
+  );
+
+  if (setter) {
+    set(update, api.name, res);
+    setter(screenDataAtom, { update });
+  }
+  return res;
+};
+
+export const handleConnectSocket = (
+  socketName: string,
+  screenContext: ScreenContextDefinition,
+  onOpen?: EnsembleActionHookResult,
+  onMessage?: EnsembleActionHookResult,
+  onClose?: EnsembleActionHookResult,
+  setter?: Setter,
+): WebSocketConnection | undefined => {
+  const socket = findSocket(socketName, screenContext);
+  if (!socket) {
+    error(`Unable to find socket ${socketName}`);
+    return;
+  }
+
+  // check the socket is already connected
+  const prevSocketConnection = screenContext.data[socket.name] as
+    | WebSocketConnection
+    | undefined;
+
+  if (prevSocketConnection?.isConnected) {
+    return prevSocketConnection;
+  }
+
+  const ws = new WebSocket(socket.uri);
+
+  if (onOpen?.callback) {
+    ws.onopen = (): unknown => onOpen.callback();
+  }
+
+  if (onMessage?.callback) {
+    ws.onmessage = (e: MessageEvent): unknown =>
+      onMessage.callback({ data: e.data as unknown });
+  }
+
+  if (onClose?.callback) {
+    ws.onclose = (): unknown => onClose.callback();
+  }
+
+  if (setter) {
+    const update = {};
+    set(update, socket.name, { socket: ws, isConnected: true });
+    setter(screenDataAtom, update);
+  }
+
+  return { socket: ws, isConnected: true };
+};
+
+export const handleMessageSocket = (
+  socketName: string,
+  message: { [key: string]: unknown },
+  screenContext: ScreenContextDefinition,
+): void => {
+  const socket = findSocket(socketName, screenContext);
+  if (!socket) {
+    error(`Unable to find socket ${socketName}`);
+    return;
+  }
+
+  const socketInstance = screenContext.data[socket.name] as WebSocketConnection;
+  if (socketInstance.isConnected) {
+    socketInstance.socket?.send(JSON.stringify(message));
+  }
+};
+
+export const handleDisconnectSocket = (
+  socketName: string,
+  screenContext: ScreenContextDefinition,
+  setter?: Setter,
+): void => {
+  const socket = findSocket(socketName, screenContext);
+  if (!socket) {
+    error(`Unable to find socket ${socketName}`);
+    return;
+  }
+
+  const socketInstance = screenContext.data[socket.name] as WebSocketConnection;
+  if (socketInstance.isConnected) {
+    socketInstance.socket?.close();
+    if (setter) {
+      const update = {};
+      set(update, socket.name, { isConnected: false });
+      setter(screenDataAtom, update);
+    }
+  }
+};
+
+const findSocket = (
+  socketName: string,
+  screenContext: ScreenContextDefinition,
+): EnsembleSocketModel | undefined =>
+  screenContext.model?.sockets?.find((model) => model.name === socketName);

--- a/packages/framework/src/api/data.ts
+++ b/packages/framework/src/api/data.ts
@@ -56,7 +56,7 @@ export const invokeAPI = async (
 
   if (setter) {
     set(update, api.name, res);
-    setter(screenDataAtom, { update });
+    setter(screenDataAtom, { ...update });
   }
   return res;
 };

--- a/packages/framework/src/api/index.ts
+++ b/packages/framework/src/api/index.ts
@@ -1,0 +1,3 @@
+export * from "./data";
+export * from "./navigate";
+export * from "./modal";

--- a/packages/framework/src/api/modal.ts
+++ b/packages/framework/src/api/modal.ts
@@ -1,0 +1,87 @@
+import { cloneDeep, isObject } from "lodash-es";
+import type { ReactNode } from "react";
+import { unwrapWidget } from "../parser";
+import type {
+  ShowDialogAction,
+  EnsembleWidget,
+  ShowDialogOptions,
+} from "../shared";
+
+export interface ModalProps {
+  title?: string | React.ReactNode;
+  maskClosable?: boolean;
+  mask?: boolean;
+  hideCloseIcon?: boolean;
+  hideFullScreenIcon?: boolean;
+  onClose?: () => void;
+  position?: "top" | "right" | "bottom" | "left" | "center";
+  height?: string;
+  width?: string | number;
+  margin?: string;
+  padding?: string;
+  backgroundColor?: string;
+  horizontalOffset?: number;
+  verticalOffset?: number;
+  showShadow?: boolean;
+}
+
+export interface ModalContext {
+  openModal: (
+    content: React.ReactNode,
+    options: ModalProps,
+    isDialog?: boolean,
+    context?: { [key: string]: unknown },
+  ) => void;
+  closeAllModals: () => void;
+  navigateBack: () => void;
+}
+
+export interface ShowDialogApiProps {
+  action?: ShowDialogAction;
+  openModal?: (...args: any[]) => void;
+  render?: (widgets: EnsembleWidget[]) => ReactNode[];
+}
+
+export const showDialog = (props?: ShowDialogApiProps): void => {
+  const { action, openModal, render } = props ?? {};
+  if (!action || !openModal || (!action.widget && !action.body)) {
+    return;
+  }
+
+  const widget = action.widget ?? action.body;
+
+  const content = widget?.name
+    ? (cloneDeep(widget) as unknown as EnsembleWidget)
+    : unwrapWidget(cloneDeep(widget!));
+
+  openModal(
+    render?.([content]),
+    getShowDialogOptions(action.options),
+    true,
+    screen || undefined,
+  );
+};
+
+export const getShowDialogOptions = (
+  options?: ShowDialogOptions,
+  onClose?: () => void,
+): ShowDialogOptions => {
+  const noneStyleOption = {
+    backgroundColor: "transparent",
+    showShadow: false,
+  };
+
+  const dialogOptions = {
+    maskClosable: true,
+    hideCloseIcon: true,
+    hideFullScreenIcon: true,
+    verticalOffset: options?.verticalOffset,
+    horizontalOffset: options?.horizontalOffset,
+    padding: "12px",
+    onClose,
+    ...(options?.style === "none" ? noneStyleOption : {}),
+    ...(isObject(options) ? options : {}),
+  };
+
+  return dialogOptions;
+};

--- a/packages/framework/src/api/navigate.tsx
+++ b/packages/framework/src/api/navigate.tsx
@@ -1,0 +1,126 @@
+import { cloneDeep, isObject, isString, merge, omit } from "lodash-es";
+import type { FC } from "react";
+import type {
+  EnsembleAppModel,
+  EnsembleScreenModel,
+  NavigateScreenAction,
+  NavigateModalScreenAction,
+  NavigateExternalScreen,
+} from "../shared";
+import type { ScreenContextDefinition } from "../state";
+import type { ModalContext } from "./modal";
+
+export interface NavigateFunction {
+  (to: string, options?: { state: { [key: string]: unknown } }): void;
+  (delta: number): void;
+}
+
+const findScreen = (
+  screenName: string,
+  app?: EnsembleAppModel | null,
+): EnsembleScreenModel | undefined => {
+  return app?.screens.find(
+    (s) => s.name?.toLowerCase() === screenName.toLowerCase(),
+  );
+};
+
+export const navigateApi = (
+  action: NavigateScreenAction,
+  screenContext: ScreenContextDefinition,
+  navigate: NavigateFunction,
+): void => {
+  const hasOptions = !isString(action);
+  const screenName = hasOptions ? action.name : action;
+
+  // find the matching screen
+  const matchingScreen = findScreen(screenName, screenContext.app);
+
+  if (!matchingScreen?.name) {
+    return;
+  }
+
+  // set additional inputs
+  const inputs =
+    !isString(action) && action.inputs ? cloneDeep(action.inputs) : {};
+
+  navigate(`/${matchingScreen.name.toLowerCase()}`, {
+    state: inputs,
+  });
+};
+
+const MODAL_SCREEN_DEFAULT_OPTIONS = {
+  maskClosable: true,
+  hideCloseIcon: true,
+  hideFullScreenIcon: true,
+  padding: "12px",
+};
+
+export const navigateModalScreen = (
+  action: NavigateModalScreenAction,
+  modalContext: ModalContext,
+  EnsembleScreen: FC<{
+    inputs?: { [key: string]: unknown };
+    screen: EnsembleScreenModel;
+  }>,
+  app?: EnsembleAppModel | null,
+  inputs?: { [key: string]: unknown },
+  title?: React.ReactNode[],
+  onClose?: () => void,
+): void => {
+  const hasOptions = !isString(action);
+  const screenName = hasOptions ? action.name : action;
+
+  const matchingScreen = findScreen(screenName, app);
+
+  if (!matchingScreen) {
+    return;
+  }
+  const modalOptions = { ...MODAL_SCREEN_DEFAULT_OPTIONS, onClose };
+  if (isObject(action)) {
+    merge(
+      modalOptions,
+      omit(action, "inputs"),
+      { ...action.styles },
+      { title: title ?? action.title },
+    );
+  }
+
+  modalContext.openModal(
+    <EnsembleScreen
+      inputs={inputs ?? (hasOptions ? action.inputs : {})}
+      screen={matchingScreen}
+    />,
+    modalOptions,
+  );
+};
+
+export const navigateUrl = (
+  url: string,
+  navigate: NavigateFunction,
+  inputs?: { [key: string]: unknown },
+): void => {
+  // set additional inputs
+  const urlInputs = inputs && isObject(inputs) ? cloneDeep(inputs) : {};
+
+  navigate(url, { state: urlInputs });
+};
+
+export const openExternalScreen = (action: NavigateExternalScreen): void => {
+  const hasOptions = !isString(action);
+  const screenUrl = hasOptions ? action.url : action;
+
+  if (!screenUrl) {
+    return;
+  }
+
+  window.open(
+    screenUrl,
+    !isString(action) && !(action.external || action.openNewTab) ? "_self" : "",
+  );
+};
+
+export const navigateExternalScreen = (
+  action: NavigateExternalScreen,
+): void => {
+  openExternalScreen(action);
+};

--- a/packages/framework/src/evaluate/binding.ts
+++ b/packages/framework/src/evaluate/binding.ts
@@ -77,7 +77,7 @@ export const createBindingAtom = <T = unknown>(
           value,
         )}`,
       );
-      return [name, value?.values];
+      return [name, value];
     });
 
     const evaluationContext = createEvaluationContext({

--- a/packages/framework/src/evaluate/context.ts
+++ b/packages/framework/src/evaluate/context.ts
@@ -1,4 +1,4 @@
-import { mapKeys, merge, keys, noop } from "lodash-es";
+import { mapKeys, merge, keys } from "lodash-es";
 import type { EnsembleContext, EnsembleInterface } from "../shared/ensemble";
 import type {
   ApplicationContextDefinition,

--- a/packages/framework/src/evaluate/context.ts
+++ b/packages/framework/src/evaluate/context.ts
@@ -1,10 +1,11 @@
-import { mapKeys, merge, keys } from "lodash-es";
-import type { EnsembleInterface } from "../shared/ensemble";
+import { mapKeys, merge, keys, noop } from "lodash-es";
+import type { EnsembleContext, EnsembleInterface } from "../shared/ensemble";
 import type {
   ApplicationContextDefinition,
   ScreenContextDefinition,
 } from "../state";
 import type { EnsembleAppModel, EnsembleThemeModel } from "../shared";
+import { isUsingMockResponse } from "../appConfig";
 
 export interface EvaluationContextProps {
   applicationContext: Omit<
@@ -25,7 +26,7 @@ export const createEvaluationContext = ({
   screenContext,
   ensemble,
   context,
-}: EvaluationContextProps): { [key: string]: unknown } => {
+}: EvaluationContextProps): EnsembleContext => {
   const theme = applicationContext.selectedTheme;
   const appInputs = merge(
     {},
@@ -46,9 +47,18 @@ export const createEvaluationContext = ({
     languages: applicationContext.application?.languages,
     themes: keys(applicationContext.application?.themes),
     theme: applicationContext.selectedTheme?.name,
+    useMockResponse: isUsingMockResponse(applicationContext.application?.id),
+    setUseMockResponse: noop,
   };
 
   const env = applicationContext.env;
 
-  return merge({}, { app, ensemble, env }, appInputs, screenInputs, context);
+  // FIXME: this requires ensemble interface to be built outside of this function
+  return merge(
+    {},
+    { app, ensemble, env },
+    appInputs,
+    screenInputs,
+    context,
+  ) as EnsembleContext;
 };

--- a/packages/framework/src/evaluate/context.ts
+++ b/packages/framework/src/evaluate/context.ts
@@ -5,7 +5,7 @@ import type {
   ScreenContextDefinition,
 } from "../state";
 import type { EnsembleAppModel, EnsembleThemeModel } from "../shared";
-import { isUsingMockResponse } from "../appConfig";
+import { isUsingMockResponse, setUseMockResponse } from "../appConfig";
 
 export interface EvaluationContextProps {
   applicationContext: Omit<
@@ -48,7 +48,8 @@ export const createEvaluationContext = ({
     themes: keys(applicationContext.application?.themes),
     theme: applicationContext.selectedTheme?.name,
     useMockResponse: isUsingMockResponse(applicationContext.application?.id),
-    setUseMockResponse: noop,
+    setUseMockResponse: (value: boolean) =>
+      setUseMockResponse(applicationContext.application?.id, value), //noop,
   };
 
   const env = applicationContext.env;

--- a/packages/framework/src/evaluate/context.ts
+++ b/packages/framework/src/evaluate/context.ts
@@ -6,6 +6,7 @@ import type {
 } from "../state";
 import type { EnsembleAppModel, EnsembleThemeModel } from "../shared";
 import { isUsingMockResponse, setUseMockResponse } from "../appConfig";
+import { widgetStatesToInvokables } from "./evaluate";
 
 export interface EvaluationContextProps {
   applicationContext: Omit<
@@ -39,7 +40,9 @@ export const createEvaluationContext = ({
   const screenInputs = merge(
     {},
     screenContext.inputs,
-    screenContext.widgets,
+    screenContext.widgets
+      ? Object.fromEntries(widgetStatesToInvokables(screenContext.widgets))
+      : {},
     screenContext.data,
   );
 

--- a/packages/framework/src/evaluate/evaluate.ts
+++ b/packages/framework/src/evaluate/evaluate.ts
@@ -1,20 +1,26 @@
 import { isEmpty, merge, toString } from "lodash-es";
 import type { ScreenContextDefinition } from "../state/screen";
-import type { InvokableMethods } from "../state/widget";
+import type { InvokableMethods, WidgetState } from "../state/widget";
 import { sanitizeJs, debug } from "../shared";
+
+export const widgetStatesToInvokables = (widgets: {
+  [key: string]: WidgetState | undefined;
+}): [string, InvokableMethods | undefined][] => {
+  return Object.entries(widgets).map(([id, state]) => {
+    const methods = state?.invokable?.methods;
+    const values = state?.values;
+    return [id, merge({}, values, methods)];
+  });
+};
 
 export const buildEvaluateFn = (
   screen: Partial<ScreenContextDefinition>,
   js?: string,
   context?: { [key: string]: unknown },
 ): (() => unknown) => {
-  const widgets: [string, InvokableMethods | undefined][] = Object.entries(
-    screen.widgets ?? {},
-  ).map(([id, state]) => {
-    const methods = state?.invokable?.methods;
-    const values = state?.values;
-    return [id, merge({}, values, methods)];
-  });
+  const widgets: [string, InvokableMethods | undefined][] = screen.widgets
+    ? widgetStatesToInvokables(screen.widgets)
+    : [];
 
   const invokableObj = Object.fromEntries(
     [

--- a/packages/framework/src/hooks/index.ts
+++ b/packages/framework/src/hooks/index.ts
@@ -14,3 +14,4 @@ export * from "./useEventContext";
 export * from "./useLanguageScope";
 export * from "./useScreenData";
 export * from "./useDeviceObserver";
+export * from "./useCommandCallback";

--- a/packages/framework/src/hooks/useCommandCallback.ts
+++ b/packages/framework/src/hooks/useCommandCallback.ts
@@ -132,6 +132,7 @@ export const useCommandCallback = <
           },
           context: {
             ...customWidgets,
+            ...customScope,
             device,
             app: {
               theme,

--- a/packages/framework/src/hooks/useCommandCallback.ts
+++ b/packages/framework/src/hooks/useCommandCallback.ts
@@ -28,7 +28,7 @@ import type {
   ShowDialogAction,
 } from "../shared";
 import { deviceAtom } from "./useDeviceObserver";
-import { useEnsembleStorage } from "./useEnsembleStorage";
+import { createStorageApi, screenStorageAtom } from "./useEnsembleStorage";
 import { useCustomScope } from "./useCustomScope";
 import { useLanguageScope } from "./useLanguageScope";
 
@@ -51,7 +51,6 @@ export const useCommandCallback = <
   callbackContext?: CallbackContext,
 ): ReturnType<typeof useAtomCallback<R, T>> => {
   const customScope = useCustomScope();
-  const storage = useEnsembleStorage();
   const { i18n } = useLanguageScope();
 
   return useAtomCallback(
@@ -59,6 +58,7 @@ export const useCommandCallback = <
       (get, set, ...args: T) => {
         const applicationContext = get(appAtom);
         const screenContext = get(screenAtom);
+        const storage = get(screenStorageAtom);
         const device = get(deviceAtom);
         const theme = get(themeAtom);
         const user = get(userAtom);
@@ -77,7 +77,9 @@ export const useCommandCallback = <
               ...user,
               setUser: (userUpdate: EnsembleUser) => set(userAtom, userUpdate),
             },
-            storage,
+            storage: createStorageApi(storage, (next) =>
+              set(screenStorageAtom, next),
+            ),
             formatter: DateFormatter(),
             env: applicationContext.env,
             secrets: applicationContext.secrets,
@@ -101,6 +103,7 @@ export const useCommandCallback = <
                   secrets: applicationContext.secrets,
                   storage: applicationContext.storage,
                 },
+                set,
               }),
             navigateExternalScreen: (url: NavigateExternalScreen) =>
               navigateExternalScreen(url),

--- a/packages/framework/src/hooks/useCommandCallback.ts
+++ b/packages/framework/src/hooks/useCommandCallback.ts
@@ -1,0 +1,150 @@
+import { useAtomCallback } from "jotai/utils";
+import type { FC, ReactNode } from "react";
+import { useCallback } from "react";
+import { mapKeys } from "lodash-es";
+import { createEvaluationContext } from "../evaluate";
+import type { EnsembleUser } from "../state";
+import { appAtom, screenAtom, themeAtom, userAtom } from "../state";
+import type { EnsembleContext } from "../shared/ensemble";
+import { DateFormatter } from "../date";
+import type { ModalContext } from "../api";
+import {
+  handleConnectSocket,
+  handleDisconnectSocket,
+  handleMessageSocket,
+  invokeAPI,
+  navigateExternalScreen,
+  navigateModalScreen,
+  showDialog,
+} from "../api";
+import type {
+  EnsembleScreenModel,
+  EnsembleWidget,
+  NavigateExternalScreen,
+  NavigateModalScreenAction,
+  ShowDialogAction,
+} from "../shared";
+import { deviceAtom } from "./useDeviceObserver";
+import { createStorageApi, screenStorageAtom } from "./useEnsembleStorage";
+import { useCustomScope } from "./useCustomScope";
+import { useLanguageScope } from "./useLanguageScope";
+
+interface CallbackContext {
+  modalContext?: ModalContext;
+  render?: (widgets: EnsembleWidget[]) => ReactNode[];
+  EnsembleScreen: FC<{
+    inputs?: { [key: string]: unknown };
+    screen: EnsembleScreenModel;
+  }>;
+}
+export const useCommandCallback = <
+  T extends unknown[] = unknown[],
+  R = unknown,
+>(
+  command: (evalContext: EnsembleContext, ...args: T) => R,
+  dependencies: unknown[] = [],
+  callbackContext?: CallbackContext,
+): ReturnType<typeof useAtomCallback<R, T>> => {
+  const customScope = useCustomScope();
+  const { i18n } = useLanguageScope();
+
+  return useAtomCallback(
+    useCallback(
+      (get, set, ...args: T) => {
+        const applicationContext = get(appAtom);
+        const screenContext = get(screenAtom);
+        const storage = get(screenStorageAtom);
+        const device = get(deviceAtom);
+        const theme = get(themeAtom);
+        const user = get(userAtom);
+
+        const customWidgets =
+          applicationContext.application?.customWidgets.reduce(
+            (acc, widget) => ({ ...acc, [widget.name]: widget }),
+            {},
+          );
+
+        const evalContext = createEvaluationContext({
+          applicationContext,
+          screenContext,
+          ensemble: {
+            user: {
+              ...user,
+              setUser: (userUpdate: EnsembleUser) => set(userAtom, userUpdate),
+            },
+            storage: createStorageApi(storage),
+            formatter: DateFormatter(),
+            env: applicationContext.env,
+            secrets: applicationContext.secrets,
+            invokeAPI: async (
+              apiName: string,
+              apiInputs?: { [key: string]: unknown },
+            ) =>
+              invokeAPI(apiName, screenContext, apiInputs, {
+                ...customScope,
+                ensemble: {
+                  env: applicationContext.env,
+                  secrets: applicationContext.secrets,
+                  storage: applicationContext.storage,
+                },
+              }),
+            navigateExternalScreen: (url: NavigateExternalScreen) =>
+              navigateExternalScreen(url),
+            openUrl: (url: NavigateExternalScreen) =>
+              navigateExternalScreen(url),
+            connectSocket: (name: string) =>
+              handleConnectSocket(
+                name,
+                screenContext,
+                undefined,
+                undefined,
+                undefined,
+                set,
+              ),
+            messageSocket: (
+              name: string,
+              message: { [key: string]: unknown },
+            ) => handleMessageSocket(name, message, screenContext),
+            disconnectSocket: (name: string) =>
+              handleDisconnectSocket(name, screenContext, set),
+            setLocale: ({ languageCode }) => i18n.changeLanguage(languageCode),
+            showDialog: (dialogAction?: ShowDialogAction): void =>
+              showDialog({
+                action: dialogAction,
+                openModal: callbackContext?.modalContext?.openModal,
+                render: callbackContext?.render,
+              }),
+            closeAllDialogs: (): void =>
+              callbackContext?.modalContext?.closeAllModals(),
+            navigateModalScreen: (
+              navigateModalScreenAction: NavigateModalScreenAction,
+            ): void => {
+              if (!callbackContext?.modalContext) {
+                return;
+              }
+              navigateModalScreen(
+                navigateModalScreenAction,
+                callbackContext.modalContext,
+                callbackContext.EnsembleScreen,
+                applicationContext.application ?? screenContext.app,
+              );
+            },
+          },
+          context: {
+            ...customWidgets,
+            device,
+            app: {
+              theme,
+            },
+            styles: theme.Styles,
+            ...mapKeys(theme.Tokens ?? {}, (_, key) => key.toLowerCase()),
+          },
+        });
+
+        return command(evalContext, ...args);
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [command, customScope, i18n, ...dependencies],
+    ),
+  );
+};

--- a/packages/framework/src/hooks/useCommandCallback.ts
+++ b/packages/framework/src/hooks/useCommandCallback.ts
@@ -25,7 +25,7 @@ import type {
   ShowDialogAction,
 } from "../shared";
 import { deviceAtom } from "./useDeviceObserver";
-import { createStorageApi, screenStorageAtom } from "./useEnsembleStorage";
+import { useEnsembleStorage } from "./useEnsembleStorage";
 import { useCustomScope } from "./useCustomScope";
 import { useLanguageScope } from "./useLanguageScope";
 
@@ -46,6 +46,7 @@ export const useCommandCallback = <
   callbackContext?: CallbackContext,
 ): ReturnType<typeof useAtomCallback<R, T>> => {
   const customScope = useCustomScope();
+  const storage = useEnsembleStorage();
   const { i18n } = useLanguageScope();
 
   return useAtomCallback(
@@ -53,7 +54,6 @@ export const useCommandCallback = <
       (get, set, ...args: T) => {
         const applicationContext = get(appAtom);
         const screenContext = get(screenAtom);
-        const storage = get(screenStorageAtom);
         const device = get(deviceAtom);
         const theme = get(themeAtom);
         const user = get(userAtom);
@@ -66,13 +66,13 @@ export const useCommandCallback = <
 
         const evalContext = createEvaluationContext({
           applicationContext,
-          screenContext,
+          screenContext: {}, // if screenContext is passed from here, it overrides values of screen's widgets in evaluate function. Yet to confirm if removal of this piece would cause any issue.
           ensemble: {
             user: {
               ...user,
               setUser: (userUpdate: EnsembleUser) => set(userAtom, userUpdate),
             },
-            storage: createStorageApi(storage),
+            storage,
             formatter: DateFormatter(),
             env: applicationContext.env,
             secrets: applicationContext.secrets,

--- a/packages/framework/src/hooks/useScreenContext.tsx
+++ b/packages/framework/src/hooks/useScreenContext.tsx
@@ -8,6 +8,7 @@ import {
   locationAtom,
   screenAtom,
   screenDataAtom,
+  screenModelAtom,
   themeAtom,
   userAtom,
 } from "../state";
@@ -118,4 +119,10 @@ export const useScreenContext = ():
   );
 
   return { ...screenContext, setData };
+};
+
+export const useScreenModel = (): EnsembleScreenModel | undefined => {
+  const model = useAtomValue(screenModelAtom);
+
+  return model;
 };

--- a/packages/framework/src/shared/ensemble.d.ts
+++ b/packages/framework/src/shared/ensemble.d.ts
@@ -1,3 +1,12 @@
+import type { Response } from "../data";
+import type { ShowDialogAction } from "./actions";
+
+export interface EnsembleContext {
+  app: EnsembleAppConfig;
+  env: EnsembleEnvConfig;
+  ensemble: EnsembleInterface;
+  [k: string]: unknown;
+}
 export interface EnsembleInterface {
   storage: EnsembleStorage;
   formatter: Partial<EnsembleFormatter>;
@@ -8,19 +17,29 @@ export interface EnsembleInterface {
   device: EnsembleDeviceInfo;
   navigateScreen: (screenName: string, inputs?: unknown[]) => void;
   navigateModalScreen: (screenName: string, inputs?: unknown[]) => void;
-  showDialog: (widget: unknown) => void;
-  invokeAPI: (apiName: string, inputs?: unknown[]) => void;
+  navigateExternalScreen: (url: NavigateExternalScreen) => void;
+  openUrl: (url: NavigateExternalScreen) => void;
+  showDialog: (action: ShowDialogAction) => void;
+  closeAllDialogs: () => void;
+  invokeAPI: (
+    apiName: string,
+    apiInputs?: { [key: string]: unknown },
+  ) => Promise<Response | undefined>;
   stopTimer: (timerId: string) => void;
   openCamera: () => void;
   navigateBack: () => void;
   showToast: (inputs: unknown) => void;
   debug: (value: unknown) => void;
   copyToClipboard: (value: unknown) => void;
+  connectSocket: (name: string) => void;
+  messageSocket: (name: string, message: { [key: string]: unknown }) => void;
+  disconnectSocket: (name: string) => void;
+  setLocale: ({ languageCode }: { languageCode: string }) => unknown;
 }
 
 interface EnsembleApiResponse {
-  body: { data: unknown } & Record<string, unknown>;
-  headers: Record<string, unknown>;
+  body: { data: unknown } & { [key: string]: unknown };
+  headers: { [key: string]: unknown };
   progress: number;
 }
 
@@ -28,4 +47,13 @@ export interface EnsembleStorage {
   set: (key: string, value: unknown) => void;
   get: (key: string) => unknown;
   delete: (key: string) => unknown;
+}
+
+interface EnsembleAppConfig {
+  useMockResponse: boolean;
+  setUseMockresponse?: (value: boolean) => void;
+}
+
+interface EnsembleUser {
+  [k: string]: unknown;
 }

--- a/packages/framework/src/shared/ensemble.d.ts
+++ b/packages/framework/src/shared/ensemble.d.ts
@@ -15,7 +15,9 @@ export interface EnsembleInterface {
   secrets: EnsembleSecretsConfig;
   user?: EnsembleUser;
   device: EnsembleDeviceInfo;
+  location: EnsembleLocation;
   navigateScreen: (screenName: string, inputs?: unknown[]) => void;
+  navigateUrl: (url: string, inputs?: { [key: string]: unknown }) => void;
   navigateModalScreen: (screenName: string, inputs?: unknown[]) => void;
   navigateExternalScreen: (url: NavigateExternalScreen) => void;
   openUrl: (url: NavigateExternalScreen) => void;
@@ -56,4 +58,13 @@ interface EnsembleAppConfig {
 
 interface EnsembleUser {
   [k: string]: unknown;
+}
+
+export interface EnsembleLocationInterface {
+  pathname?: string;
+  search?: string;
+}
+
+export interface EnsembleLocation {
+  get: (key: keyof EnsembleLocationInterface) => string | undefined;
 }

--- a/packages/framework/src/state/screen.ts
+++ b/packages/framework/src/state/screen.ts
@@ -45,6 +45,10 @@ export const screenDataAtom = atom(
   },
 );
 
+export const screenModelAtom = focusAtom(screenAtom, (optic) =>
+  optic.prop("model"),
+);
+
 export const screenApiAtom = focusAtom(screenAtom, (optic) => {
   return optic.prop("model").optional().prop("apis");
 });

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -14,6 +14,7 @@ import {
   isUsingMockResponse,
   mockResponse,
   useCommandCallback,
+  useScreenModel,
 } from "@ensembleui/react-framework";
 import type {
   InvokeAPIAction,
@@ -96,7 +97,7 @@ export const useExecuteCode: EnsembleActionHook<
   UseExecuteCodeActionOptions
 > = (action, options) => {
   const isCodeString = isString(action);
-  const screen = useScreenContext();
+  const screenModel = useScreenModel();
   const modalContext = useContext(ModalContext);
   const navigate = useNavigate();
   const location = useLocation();
@@ -127,13 +128,13 @@ export const useExecuteCode: EnsembleActionHook<
 
   const execute = useCommandCallback(
     (evalContext, ...args: unknown[]) => {
-      if (!screen || !js) {
+      if (!js) {
         return;
       }
       const context = merge({}, evalContext, ...args, options?.context) as {
         [key: string]: unknown;
       };
-      const retVal = evaluate(screen, js, context);
+      const retVal = evaluate({ model: screenModel }, js, context);
       onCompleteAction?.callback({
         ...(args[0] as { [key: string]: unknown }),
         result: retVal,
@@ -141,7 +142,7 @@ export const useExecuteCode: EnsembleActionHook<
       return retVal;
     },
     { navigate, location: locationApi(location) },
-    [js, onCompleteAction],
+    [js, onCompleteAction, screenModel],
     { modalContext, render: EnsembleRuntime.render, EnsembleScreen },
   );
 

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -92,7 +92,7 @@ export interface UseExecuteCodeActionOptions {
 export const useExecuteCode: EnsembleActionHook<
   ExecuteCodeAction,
   UseExecuteCodeActionOptions
-> = (action) => {
+> = (action, options) => {
   const isCodeString = isString(action);
   const screen = useScreenContext();
   const modalContext = useContext(ModalContext);
@@ -126,7 +126,7 @@ export const useExecuteCode: EnsembleActionHook<
       if (!screen || !js) {
         return;
       }
-      const context = merge({}, evalContext, ...args) as {
+      const context = merge({}, evalContext, ...args, options?.context) as {
         [key: string]: unknown;
       };
       const retVal = evaluate(screen, js, context);

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -48,9 +48,11 @@ import {
   toNumber,
 } from "lodash-es";
 import { useState, useEffect, useMemo, useCallback, useContext } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { ModalContext } from "../modal";
 import { EnsembleRuntime } from "../runtime";
 import { getShowDialogOptions } from "../showDialog";
+import { locationApi } from "../locationApi";
 import {
   handleConnectSocket,
   handleMessageSocket,
@@ -96,6 +98,8 @@ export const useExecuteCode: EnsembleActionHook<
   const isCodeString = isString(action);
   const screen = useScreenContext();
   const modalContext = useContext(ModalContext);
+  const navigate = useNavigate();
+  const location = useLocation();
   const appContext = useApplicationContext();
   const onCompleteAction = useEnsembleAction(
     isCodeString ? undefined : action?.onComplete,
@@ -136,6 +140,7 @@ export const useExecuteCode: EnsembleActionHook<
       });
       return retVal;
     },
+    { navigate, location: locationApi(location) },
     [js, onCompleteAction],
     { modalContext, render: EnsembleRuntime.render, EnsembleScreen },
   );

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -123,11 +123,14 @@ export const useExecuteCode: EnsembleActionHook<
   }, [action, isCodeString, appContext?.application?.scripts]);
 
   const execute = useCommandCallback(
-    (evalContext, ...args) => {
+    (evalContext, ...args: unknown[]) => {
       if (!screen || !js) {
         return;
       }
-      const retVal = evaluate(defaultScreenContext, js, evalContext);
+      const context = merge({}, evalContext, ...args) as {
+        [key: string]: unknown;
+      };
+      const retVal = evaluate(screen, js, context);
       onCompleteAction?.callback({
         ...(args[0] as { [key: string]: unknown }),
         result: retVal,

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -14,7 +14,6 @@ import {
   isUsingMockResponse,
   mockResponse,
   useCommandCallback,
-  defaultScreenContext,
 } from "@ensembleui/react-framework";
 import type {
   InvokeAPIAction,

--- a/packages/runtime/src/runtime/locationApi.tsx
+++ b/packages/runtime/src/runtime/locationApi.tsx
@@ -12,7 +12,7 @@ export interface EnsembleLocation {
 export const locationApi = (location: Location): EnsembleLocation => {
   return {
     get: (key: keyof EnsembleLocationInterface): string | undefined => {
-      return location?.[key];
+      return location[key];
     },
   };
 };


### PR DESCRIPTION
## Describe your changes

Refactors useExecuteCode dependencies to be fetched at execution instead of re-render, which should greatly improve performance. This required refactoring a bunch of dependencies into framework project and needs to be cleaned up further.

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
