### PR TITLE
fix: improve dropdown panel performance

### DIFF
--- a/.changeset/strange-impalas-act.md
+++ b/.changeset/strange-impalas-act.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+improve dropdown panel performance

--- a/packages/runtime/src/widgets/Form/Dropdown.tsx
+++ b/packages/runtime/src/widgets/Form/Dropdown.tsx
@@ -64,20 +64,22 @@ const DropdownRenderer = (
   menu: React.ReactElement,
   panel?: { [key: string]: unknown },
 ): React.ReactElement => {
+  const panelOption = useMemo(() => {
+    return panel ? EnsembleRuntime.render([unwrapWidget(panel)]) : null;
+  }, []);
+
   return (
     <>
       {menu}
-      {panel ? (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-        <div
-          onMouseDown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-        >
-          {EnsembleRuntime.render([unwrapWidget(panel)])}
-        </div>
-      ) : null}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div
+        onMouseDown={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+      >
+        {panelOption}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Describe your changes
Improve dropdown performance, previously it was in infinite loop and consume large memory of browser tab

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
