### PR TITLE
only show one error message at a time in form fields

### DIFF
--- a/.changeset/giant-laws-know.md
+++ b/.changeset/giant-laws-know.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+Added fix for show only one error message for multiple validation rule

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -138,10 +138,10 @@ View:
                     # If you omit id, the form value key will be the label
                     - TextInput:
                         id: formTextInput
-                        value: ${ensemble.storage.get('inputVal')}
                         hintText: (123) 456-7890
                         mask: "(###) ###-####"
                         inputType: phone
+                        required: true
                         label:
                           Text:
                             text: Text input
@@ -158,6 +158,7 @@ View:
                         label: Text input with min and max length
                     - TextInput:
                         id: regexTextInput
+                        required: true
                         validator:
                           regex: .{1,}
                           regexError: "write something atleast"

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -204,6 +204,12 @@ View:
                         label: Date 2
                         value: "2024/04/04"
                         hintText: Choose date 2
+                    - TextInput:
+                        id: customNumberInput
+                        required: true
+                        validator:
+                          regex: ^\d{10}$
+                          regexError: "Please enter a 10 digit number"
                     - Button:
                         submitForm: true
                         label: Submit

--- a/packages/runtime/src/widgets/Form/FormItem.tsx
+++ b/packages/runtime/src/widgets/Form/FormItem.tsx
@@ -43,7 +43,10 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
       initialValue={values?.initialValue}
       label={fieldLabel}
       messageVariables={{
-        label: isString(values?.label) ? values.label : values?.id || "",
+        label:
+          values?.label && isString(values.label)
+            ? values.label
+            : values?.id || "",
       }}
       name={formInstance ? values?.id ?? values?.label : undefined}
       rules={[requiredRule, ...(rules || [])]}

--- a/packages/runtime/src/widgets/Form/FormItem.tsx
+++ b/packages/runtime/src/widgets/Form/FormItem.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { FormItemProps } from "antd";
 import { Form as AntForm } from "antd";
 import { isString } from "lodash-es";
@@ -20,28 +21,32 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
   const formInstance = AntForm.useFormInstance();
   const requiredRule = { required: Boolean(values?.required) };
 
+  const fieldLabel = useMemo(() => {
+    return values?.label ? (
+      <label
+        htmlFor={values.id ?? values.label}
+        style={{
+          ...values.labelStyle,
+        }}
+        title={values.label}
+      >
+        {isString(values.label)
+          ? values.label
+          : EnsembleRuntime.render([unwrapWidget(values.label)])}
+      </label>
+    ) : null;
+  }, []);
+
   return (
     <AntForm.Item
       className={values?.styles?.names}
       initialValue={values?.initialValue}
-      label={
-        values?.label ? (
-          <label
-            htmlFor={values.id ?? values.label}
-            style={{
-              ...values.labelStyle,
-            }}
-            title={values.label}
-          >
-            {isString(values.label)
-              ? values.label
-              : EnsembleRuntime.render([unwrapWidget(values.label)])}
-          </label>
-        ) : null
-      }
-      messageVariables={{ label: values?.label ?? values?.id ?? "" }}
+      label={fieldLabel}
+      messageVariables={{
+        label: isString(values?.label) ? values.label : values?.id || "",
+      }}
       name={formInstance ? values?.id ?? values?.label : undefined}
-      rules={rules?.concat(requiredRule) || [requiredRule]}
+      rules={[requiredRule, ...(rules || [])]}
       style={{
         margin: "0px",
         ...(values?.styles?.visible === false

--- a/packages/runtime/src/widgets/Form/FormItem.tsx
+++ b/packages/runtime/src/widgets/Form/FormItem.tsx
@@ -47,7 +47,7 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
       initialValue={values?.initialValue}
       label={fieldLabel}
       messageVariables={{
-        label: isString(values?.label) ? values?.label : values?.id || "",
+        label: (isString(values?.label) ? values?.label : values?.id) || "",
       }}
       name={formInstance ? values?.id ?? values?.label : undefined}
       rules={[requiredRule, ...(rules || [])]}

--- a/packages/runtime/src/widgets/Form/FormItem.tsx
+++ b/packages/runtime/src/widgets/Form/FormItem.tsx
@@ -49,6 +49,7 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
           : undefined),
         ...formItemStyles,
       }}
+      validateFirst
       validateTrigger={
         values?.validateOnUserInteraction === true ? "onChange" : "onSubmit"
       }

--- a/packages/runtime/src/widgets/Form/FormItem.tsx
+++ b/packages/runtime/src/widgets/Form/FormItem.tsx
@@ -22,7 +22,11 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
   const requiredRule = { required: Boolean(values?.required) };
 
   const fieldLabel = useMemo(() => {
-    return values?.label ? (
+    if (!values?.label) {
+      return null;
+    }
+
+    return (
       <label
         htmlFor={values.id ?? values.label}
         style={{
@@ -34,7 +38,7 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
           ? values.label
           : EnsembleRuntime.render([unwrapWidget(values.label)])}
       </label>
-    ) : null;
+    );
   }, []);
 
   return (
@@ -43,10 +47,7 @@ export const EnsembleFormItem: React.FC<EnsembleFormItemProps<unknown>> = (
       initialValue={values?.initialValue}
       label={fieldLabel}
       messageVariables={{
-        label:
-          values?.label && isString(values.label)
-            ? values.label
-            : values?.id || "",
+        label: isString(values?.label) ? values?.label : values?.id || "",
       }}
       name={formInstance ? values?.id ?? values?.label : undefined}
       rules={[requiredRule, ...(rules || [])]}


### PR DESCRIPTION
## Describe your changes
Added fix for show only one error message on form field for validate

### Screenshots [Optional]
Before
<img width="685" alt="image" src="https://github.com/user-attachments/assets/09d82dcb-08d0-49bb-880c-cfc7dd199fdb">


After
<img width="518" alt="image" src="https://github.com/user-attachments/assets/303462e6-252e-42bb-a2bb-899d0c6e2580">


## Issue ticket number and link

Closes #837 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
