### PR TITLE
fix: button loader on component re-initialized

### DIFF
--- a/.changeset/happy-pears-suffer.md
+++ b/.changeset/happy-pears-suffer.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+fix loader on on second time button load

--- a/packages/runtime/src/widgets/Button.tsx
+++ b/packages/runtime/src/widgets/Button.tsx
@@ -31,7 +31,7 @@ export type ButtonProps = {
 } & EnsembleWidgetProps;
 
 export const Button: React.FC<ButtonProps> = ({ id, onTap, ...rest }) => {
-  const [loading, setLoading] = useState<boolean>(rest.loading || false);
+  const [loading, setLoading] = useState<boolean>();
   const action = useEnsembleAction(onTap);
   const onClickCallback = useCallback(
     (e?: MouseEvent) => {


### PR DESCRIPTION
## Describe your changes
Previously when button in placed in showDialog and start the loader of button, then close the dialog and open again, the button widget will be traped inside infinite re-render

### Screenshots [Optional]

before

https://github.com/user-attachments/assets/8f4abffa-0a49-4682-a7e5-20237f7a83fa

after

https://github.com/user-attachments/assets/44e3a900-625c-4a1b-b0d0-01e7a0b3740d

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app



