### PR TITLE
fix: added support for decimal in textInput number

### DIFF
--- a/.changeset/afraid-bikes-poke.md
+++ b/.changeset/afraid-bikes-poke.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+added support for decimal in input type number

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -183,10 +183,10 @@ View:
                         hintText: "Enter a number"
                         hintStyle:
                           color: red
-                        maxLength: 2
+                        maxLength: 3
                         validator:
                           required: true
-                          maxLength: 2
+                          maxLength: 3
                         label: Text input with min and max length
                     - TextInput:
                         id: regexTextInput

--- a/packages/runtime/src/widgets/Form/TextInput.tsx
+++ b/packages/runtime/src/widgets/Form/TextInput.tsx
@@ -77,7 +77,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
 
   const handleKeyDown = useCallback((e: FormEvent<HTMLInputElement>) => {
     const target = e.target as HTMLInputElement;
-    target.value = target.value.replace(/[^0-9]/g, "");
+    target.value = target.value.replace(/[^0-9.]/g, "");
   }, []);
 
   useEffect(() => {

--- a/packages/runtime/src/widgets/Form/__tests__/TextInput.test.tsx
+++ b/packages/runtime/src/widgets/Form/__tests__/TextInput.test.tsx
@@ -70,6 +70,7 @@ describe("TextInput", () => {
     fireEvent.click(getValueButton);
 
     await waitFor(() => {
+      expect(screen.getByDisplayValue("12.3")).toBeVisible();
       expect(logSpy).toHaveBeenCalledWith(
         expect.objectContaining({ numberInput: "12.3" }),
       );
@@ -132,6 +133,7 @@ describe("TextInput", () => {
     fireEvent.click(getValueButton);
 
     await waitFor(() => {
+      expect(screen.getByDisplayValue("1.23")).toBeVisible();
       expect(logSpy).toHaveBeenCalledWith(
         expect.objectContaining({ numberInput: "1.23" }),
       );

--- a/packages/runtime/src/widgets/Form/__tests__/TextInput.test.tsx
+++ b/packages/runtime/src/widgets/Form/__tests__/TextInput.test.tsx
@@ -55,6 +55,27 @@ describe("TextInput", () => {
     });
   });
 
+  test("allows numeric keys to be entered with decimal", async () => {
+    render(
+      <Form
+        children={[...defaultFormContent, ...defaultFormButton]}
+        id="form"
+      />,
+      { wrapper: FormTestWrapper },
+    );
+    const input = screen.getByLabelText("Number input");
+    fireEvent.change(input, { target: { value: "12.3" } });
+
+    const getValueButton = screen.getByText("Get Value");
+    fireEvent.click(getValueButton);
+
+    await waitFor(() => {
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ numberInput: "12.3" }),
+      );
+    });
+  });
+
   test("filter numeric keys to be entered", async () => {
     render(
       <Form
@@ -82,6 +103,37 @@ describe("TextInput", () => {
     await waitFor(() => {
       expect(logSpy).toHaveBeenCalledWith(
         expect.objectContaining({ numberInput: "123" }),
+      );
+    });
+  });
+
+  test("filter numeric keys to be entered with decimal", async () => {
+    render(
+      <Form
+        children={[
+          {
+            name: "TextInput",
+            properties: {
+              inputType: "number",
+              label: "Number input",
+              id: "numberInput",
+            },
+          },
+          ...defaultFormButton,
+        ]}
+        id="form"
+      />,
+      { wrapper: FormTestWrapper },
+    );
+    const input = screen.getByLabelText("Number input");
+    userEvent.type(input, "Hello 1.23");
+
+    const getValueButton = screen.getByText("Get Value");
+    fireEvent.click(getValueButton);
+
+    await waitFor(() => {
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ numberInput: "1.23" }),
       );
     });
   });


### PR DESCRIPTION
## Describe your changes
Added support for decimal in textInput number

### Screenshots [Optional]

## Issue ticket number and link

Closes #868 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
