### PR TITLE
remove default scrollHeight in Datagrid to get rid of unwanted vertical scrollbar

### DIFF
--- a/.changeset/odd-eagles-whisper.md
+++ b/.changeset/odd-eagles-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+remove default scrollHeight in Datagrid to get rid of unwanted vertical scrollbar

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -495,7 +495,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
           scroll={
             values?.scroll
               ? {
-                  y: values.scroll.scrollHeight || 150,
+                  y: values.scroll.scrollHeight,
                   x: values.scroll.scrollWidth || "max-content",
                 }
               : undefined


### PR DESCRIPTION
## Describe your changes

### Screenshots [Optional]
before:
<img width="1800" alt="trinity-1428-reports-before" src="https://github.com/user-attachments/assets/5abfbc38-b0cc-4041-983c-876f88da5777">

after:
<img width="1800" alt="trinity-1428-reports-after" src="https://github.com/user-attachments/assets/e947942e-3010-4bdb-a7f4-8a9d92e26fd6">

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
