### PR TITLE
fix: added support for await in executeCodeBlock

### DIFF
--- a/.changeset/fluffy-islands-act.md
+++ b/.changeset/fluffy-islands-act.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+Added support for await in executeCodeBlock

--- a/apps/kitchen-sink/src/ensemble/screens/home.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/home.yaml
@@ -1,12 +1,19 @@
 View:
   onLoad:
-    executeCode: |
-      ensemble.storage.set('yyy' , 'page')
-      ensemble.storage.set('zzz' , 'button')
-      ensemble.storage.set('aaa' , '1')
-      ensemble.storage.set('bbb' , "0xffb91c1c")
-      ensemble.storage.set('loading', true);
-      console.log('>>> secret variable >>>', ensemble.secrets.dummyOauthSecret)
+    executeCode:
+      body: |-
+        ensemble.storage.set('yyy' , 'page')
+        ensemble.storage.set('zzz' , 'button')
+        ensemble.storage.set('aaa' , '1')
+        ensemble.storage.set('bbb' , "0xffb91c1c")
+        ensemble.storage.set('loading', true);
+        console.log('>>> secret variable >>>', ensemble.secrets.dummyOauthSecret)
+        const res = await ensemble.invokeAPI('getDummyNumbers')
+        await new Promise((resolve) => setTimeout(resolve, 5000))
+        return res
+      onComplete:
+        executeCode: |
+          console.log('API triggered', result)
 
   header:
     title:
@@ -394,3 +401,9 @@ API:
   ERROR500:
     method: GET
     uri: https://httpstat.us/500
+
+  getDummyNumbers:
+    method: GET
+    uri: https://661e111b98427bbbef034208.mockapi.io/number?limit=10
+    onResponse: |
+      console.log('dummy number fetched')

--- a/packages/runtime/src/runtime/hooks/__tests__/useActionGroup.test.tsx
+++ b/packages/runtime/src/runtime/hooks/__tests__/useActionGroup.test.tsx
@@ -158,8 +158,10 @@ test("fetch multiple APIs", async () => {
     fireEvent.click(button);
   });
 
-  expect(logSpy).toHaveBeenCalledWith("foo");
-  expect(logSpy).toHaveBeenCalledWith("bar");
+  await waitFor(() => {
+    expect(logSpy).toHaveBeenCalledWith("foo");
+    expect(logSpy).toHaveBeenCalledWith("bar");
+  });
 });
 
 test("mutate multiple storage variables", () => {

--- a/packages/runtime/src/runtime/hooks/__tests__/useEnsembleAction.test.tsx
+++ b/packages/runtime/src/runtime/hooks/__tests__/useEnsembleAction.test.tsx
@@ -48,16 +48,17 @@ describe("Test cases for useEnsembleAction Hook", () => {
     expect(result.current).toBeUndefined();
   });
 
-  it("should return useExecuteCode when action is a string", () => {
+  it("should return useExecuteCode when action is a string", async () => {
     const { result } = renderHook(() => useEnsembleAction("myWidget.value"), {
       wrapper,
     });
 
     let execResult;
 
-    act(() => {
-      execResult = result.current?.callback();
+    await act(async () => {
+      execResult = await result.current?.callback();
     });
+
     expect(execResult).toBe(2);
   });
 });

--- a/packages/runtime/src/runtime/hooks/__tests__/useExecuteCode.test.tsx
+++ b/packages/runtime/src/runtime/hooks/__tests__/useExecuteCode.test.tsx
@@ -41,19 +41,19 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   </ScreenContextProvider>
 );
 
-test("populates screen invokables in function context", () => {
+test("populates screen invokables in function context", async () => {
   const { result } = renderHook(() => useExecuteCode("myWidget.value"), {
     wrapper,
   });
 
   let execResult;
-  act(() => {
-    execResult = result.current?.callback();
+  await act(async () => {
+    execResult = await result.current?.callback();
   });
   expect(execResult).toBe(2);
 });
 
-test("populates context passed in", () => {
+test("populates context passed in", async () => {
   const { result } = renderHook(
     () =>
       useExecuteCode("specialScope.value", {
@@ -63,25 +63,25 @@ test("populates context passed in", () => {
   );
 
   let execResult;
-  act(() => {
-    execResult = result.current?.callback();
+  await act(async () => {
+    execResult = await result.current?.callback();
   });
   expect(execResult).toBe(4);
 });
 
-test("can be invoked multiple times", () => {
+test("can be invoked multiple times", async () => {
   const { result } = renderHook(() => useExecuteCode("myWidget.value"), {
     wrapper,
   });
 
   let execResult;
-  act(() => {
-    execResult = result.current?.callback();
+  await act(async () => {
+    execResult = await result.current?.callback();
   });
   expect(execResult).toBe(2);
   let execResult2;
-  act(() => {
-    execResult2 = result.current?.callback();
+  await act(async () => {
+    execResult2 = await result.current?.callback();
   });
   expect(execResult2).toBe(2);
 });

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -135,9 +135,12 @@ export const useExecuteCode: EnsembleActionHook<
         [key: string]: unknown;
       };
 
-      let executableJS = js;
-      if (js.includes("await")) {
-        executableJS = `(async () => {
+      let executableJS = `return (async () => {
+          return ${js}
+        })()`;
+
+      if (js.includes("\n")) {
+        executableJS = `return (async () => {
           ${js}
         })()`;
       }

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -127,14 +127,27 @@ export const useExecuteCode: EnsembleActionHook<
   }, [action, isCodeString, appContext?.application?.scripts]);
 
   const execute = useCommandCallback(
-    (evalContext, ...args: unknown[]) => {
+    async (evalContext, ...args: unknown[]) => {
       if (!js) {
         return;
       }
       const context = merge({}, evalContext, ...args, options?.context) as {
         [key: string]: unknown;
       };
-      const retVal = evaluate({ model: screenModel }, js, context);
+
+      let executableJS = js;
+      if (js.includes("await")) {
+        executableJS = `(async () => {
+          ${js}
+        })()`;
+      }
+
+      const retVal = await evaluate(
+        { model: screenModel },
+        executableJS,
+        context,
+      );
+
       onCompleteAction?.callback({
         ...(args[0] as { [key: string]: unknown }),
         result: retVal,


### PR DESCRIPTION
## Describe your changes
Added support for await in executeCodeBlock

### Screenshots [Optional]

## Issue ticket number and link

Closes #638 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
