### PR TITLE
[921] fix: register initialValue binding for Search widget

### DIFF
--- a/.changeset/fluffy-apes-kick.md
+++ b/.changeset/fluffy-apes-kick.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+register initialValue binding for Search widget instead of setting raw data

--- a/packages/runtime/src/widgets/Search.tsx
+++ b/packages/runtime/src/widgets/Search.tsx
@@ -186,8 +186,8 @@ export const Search: React.FC<SearchProps> = ({
   );
 
   useEffect(() => {
-    if (!value) setValue(initialValue);
-  }, [value, initialValue]);
+    if (!value) setValue(values?.initialValue);
+  }, [value, values?.initialValue]);
 
   return (
     <div


### PR DESCRIPTION
## Describe your changes
Instead of setting the unparsed initial value, set the parsed initial value from the registered bindings.
### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
