### PR TITLE
fix: improve regex of replacer in evaluateDeep

### DIFF
--- a/.changeset/good-chicken-wonder.md
+++ b/.changeset/good-chicken-wonder.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-framework": patch
+---
+
+fixed the regression related invokeAPI inputs evaluation

--- a/packages/framework/src/shared/common.ts
+++ b/packages/framework/src/shared/common.ts
@@ -163,13 +163,16 @@ export const error = (value: unknown): void => {
 export const replace =
   (replacer: (expr: string) => string) =>
   (val: string): unknown => {
-    const matches = val.match(/\$\{+[^}]+\}+/g);
+    const matches = val.match(/\$\{(?:[^}{]+|\{(?:[^}{]+|\{[^}{]*\})*\})*\}/g);
     if (matches?.length === 1 && matches[0] === val) {
       return replacer(val);
     }
-    return val.replace(/\$\{+[^}]+\}+/g, (expression) => {
-      return replacer(expression);
-    });
+    return val.replace(
+      /\$\{(?:[^}{]+|\{(?:[^}{]+|\{[^}{]*\})*\})*\}/g,
+      (expression) => {
+        return replacer(expression);
+      },
+    );
   };
 
 export const visitExpressions = (

--- a/packages/framework/src/shared/common.ts
+++ b/packages/framework/src/shared/common.ts
@@ -163,16 +163,14 @@ export const error = (value: unknown): void => {
 export const replace =
   (replacer: (expr: string) => string) =>
   (val: string): unknown => {
-    const matches = val.match(/\$\{(?:[^}{]+|\{(?:[^}{]+|\{[^}{]*\})*\})*\}/g);
+    const replaceRegex = /\$\{(?:[^}{]+|\{(?:[^}{]+|\{[^}{]*\})*\})*\}/g;
+    const matches = val.match(replaceRegex);
     if (matches?.length === 1 && matches[0] === val) {
       return replacer(val);
     }
-    return val.replace(
-      /\$\{(?:[^}{]+|\{(?:[^}{]+|\{[^}{]*\})*\})*\}/g,
-      (expression) => {
-        return replacer(expression);
-      },
-    );
+    return val.replace(replaceRegex, (expression) => {
+      return replacer(expression);
+    });
   };
 
 export const visitExpressions = (

--- a/packages/framework/src/shared/common.ts
+++ b/packages/framework/src/shared/common.ts
@@ -162,10 +162,11 @@ export const error = (value: unknown): void => {
 
 export const validateExpressions = (
   value: string,
-): { isValid: boolean; expression: string } => {
+): { isValid: boolean; expressions: string[] } => {
   let expression = "";
   let stake = 0;
   let status = "pending";
+  const expressions = [];
 
   for (let i = 0; i < value.length; i++) {
     const keyword = value[i];
@@ -180,7 +181,8 @@ export const validateExpressions = (
       expression = expression + keyword;
       if (stake === 0) {
         status = "valid";
-        break;
+        expressions.push(expression);
+        continue;
       }
       stake--;
     } else if (status === "initiate") {
@@ -189,18 +191,22 @@ export const validateExpressions = (
   }
   return {
     isValid: status === "valid",
-    expression,
+    expressions,
   };
 };
 
 export const replace =
   (replacer: (expr: string) => string) =>
   (val: string): unknown => {
-    const { expression, isValid } = validateExpressions(val);
+    const { expressions, isValid } = validateExpressions(val);
     if (isValid) {
-      return val.replace(expression, (value) => {
-        return replacer(value);
+      let replacedValue = val;
+      expressions.forEach((expr) => {
+        replacedValue = replacedValue.replace(expr, (value) => {
+          return replacer(value);
+        });
       });
+      return replacedValue;
     }
     return val;
   };

--- a/packages/framework/src/shared/common.ts
+++ b/packages/framework/src/shared/common.ts
@@ -165,36 +165,34 @@ export const validateExpressions = (
 ): { isValid: boolean; expressions: string[] } => {
   const expressions: string[] = [];
   let currentExpr = "";
-  let depth = 0;
-  let i = 0;
+  let nestCount = 0;
 
-  while (i < value.length) {
+  for (let i = 0; i < value.length; i++) {
     if (value[i] === "$" && value[i + 1] === "{") {
-      if (depth === 0) {
+      if (nestCount === 0) {
         currentExpr = "";
       }
-      depth++;
+      nestCount++;
       currentExpr += value.slice(i, i + 2);
-      i += 2;
+      i++;
       continue;
     }
 
-    if (depth > 0) {
+    if (nestCount > 0) {
       currentExpr += value[i];
       if (value[i] === "{") {
-        depth++;
+        nestCount++;
       } else if (value[i] === "}") {
-        depth--;
-        if (depth === 0) {
+        nestCount--;
+        if (nestCount === 0) {
           expressions.push(currentExpr);
         }
       }
     }
-    i++;
   }
 
   return {
-    isValid: depth === 0 && expressions.length > 0,
+    isValid: nestCount === 0 && expressions.length > 0,
     expressions,
   };
 };

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -218,8 +218,8 @@ export const useInvokeAPI: EnsembleActionHook<InvokeAPIAction> = (action) => {
             DataFetcher.fetch(
               currentApi,
               {
-                ...evaluatedInputs,
                 ...context,
+                ...evaluatedInputs,
                 ensemble: {
                   env: appContext?.env,
                   secrets: appContext?.secrets,


### PR DESCRIPTION
## Describe your changes
Improve regex of replacer in evaluateDeep

### Screenshots [Optional]

## Issue ticket number and link
The current regex is not capable to evaluate `${ensemble.user.userDetails?.clients?.map(({id}) => id) ?? []}`

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [x] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
