### PR TITLE
fix: prevent modalContext override in API response handler

### DIFF
--- a/.changeset/brave-geckos-deny.md
+++ b/.changeset/brave-geckos-deny.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+Fix executeCode context order

--- a/.changeset/brave-geckos-deny.md
+++ b/.changeset/brave-geckos-deny.md
@@ -2,4 +2,4 @@
 "@ensembleui/react-runtime": patch
 ---
 
-Fix executeCode context order
+Fix prevent modalContext override in API response handler

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -178,7 +178,7 @@ export const useInvokeAPI: EnsembleActionHook<InvokeAPIAction> = (action) => {
     async (evalContext, ...args: unknown[]) => {
       if (!action?.name || !currentApi) return;
 
-      const context = merge({}, evalContext, ...args) as {
+      const context = merge({}, evalContext, args[0]) as {
         [key: string]: unknown;
       };
 

--- a/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
+++ b/packages/runtime/src/runtime/hooks/useEnsembleAction.tsx
@@ -134,7 +134,7 @@ export const useExecuteCode: EnsembleActionHook<
       if (!js) {
         return;
       }
-      const context = merge({}, evalContext, ...args, options?.context) as {
+      const context = merge({}, ...args, options?.context, evalContext) as {
         [key: string]: unknown;
       };
       const retVal = evaluate({ model: screenModel }, js, context);


### PR DESCRIPTION
## Describe your changes
prevent modalContext override in API response handler

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
