### PR TITLE
fix: allow reset options on clear search

### DIFF
--- a/.changeset/four-apples-beg.md
+++ b/.changeset/four-apples-beg.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-runtime": patch
+---
+
+Allow reset options on clear search in multiselect and search

--- a/packages/runtime/src/widgets/Form/MultiSelect.tsx
+++ b/packages/runtime/src/widgets/Form/MultiSelect.tsx
@@ -14,7 +14,7 @@ import {
 } from "@ensembleui/react-framework";
 import { PlusCircleOutlined } from "@ant-design/icons";
 import { Select as SelectComponent, Space, Form } from "antd";
-import { get, isArray, isEmpty, isEqual, isObject, isString } from "lodash-es";
+import { get, isArray, isEqual, isObject, isString } from "lodash-es";
 import { useDebounce } from "react-use";
 import { WidgetRegistry } from "../../registry";
 import { useEnsembleAction } from "../../runtime/hooks/useEnsembleAction";
@@ -170,7 +170,7 @@ const MultiSelect: React.FC<MultiSelectProps> = (props) => {
 
   useDebounce(
     () => {
-      if (onSearchAction?.callback && !isEmpty(searchValue)) {
+      if (onSearchAction?.callback) {
         onSearchAction.callback({ search: searchValue });
       }
     },

--- a/packages/runtime/src/widgets/Search.tsx
+++ b/packages/runtime/src/widgets/Search.tsx
@@ -119,7 +119,7 @@ export const Search: React.FC<SearchProps> = ({
 
   useDebounce(
     () => {
-      if (onSearchAction?.callback && !isEmpty(searchValue)) {
+      if (onSearchAction?.callback) {
         onSearchAction.callback({ search: searchValue });
       }
     },


### PR DESCRIPTION
## Describe your changes
Allow reset options on clear search in multiselect and search

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
