### PR TITLE
add secrets support in firestore app transporter

### DIFF
--- a/.changeset/spotty-games-battle.md
+++ b/.changeset/spotty-games-battle.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/js-commons": patch
+---
+
+feat: add secrets support in firestore app transporter

--- a/packages/js-commons/src/core/dto.ts
+++ b/packages/js-commons/src/core/dto.ts
@@ -61,6 +61,7 @@ export interface ApplicationDTO
   readonly assets?: AssetDTO[];
   readonly fonts?: FontDTO[];
   readonly env?: EnvironmentDTO;
+  readonly secrets?: SecretDTO;
   readonly translations?: TranslationDTO[];
 }
 
@@ -111,6 +112,10 @@ export interface EnvironmentDTO {
   readonly secretVariables?: Record<string, unknown>;
 }
 
+export interface SecretDTO {
+  readonly secrets?: Record<string, unknown>;
+}
+
 export type AssetDTO = EnsembleDocument & {
   readonly type: EnsembleDocumentType.Asset;
   readonly fileName: string;
@@ -151,5 +156,6 @@ export const ArtifactProps = [
   "fonts",
   "translations",
   "env",
+  "secrets",
   "theme",
 ] as const;

--- a/packages/js-commons/src/core/firebase.ts
+++ b/packages/js-commons/src/core/firebase.ts
@@ -79,6 +79,7 @@ export const getFirestoreApplicationTransporter = (
       EnsembleDocumentType.I18n
     ] as TranslationDTO[];
     const env = head(artifactsByType[EnsembleDocumentType.Environment]);
+    const secrets = head(artifactsByType[EnsembleDocumentType.Secrets]);
 
     return {
       ...app,
@@ -90,6 +91,7 @@ export const getFirestoreApplicationTransporter = (
       translations,
       assets,
       env,
+      secrets,
       fonts,
       manifest: Object.fromEntries(
         Object.values(artifactsByType).flatMap((artifacts) =>


### PR DESCRIPTION
## Describe your changes

### Screenshots [Optional]

https://github.com/user-attachments/assets/b3d25225-e24e-4243-bd69-8f1ef71794e8


https://github.com/user-attachments/assets/0bcef11a-cf9f-4397-9c81-f652dc9c91b4


## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
