### PR TITLE
fix: add global or import scripts into DOM

### DIFF
--- a/apps/kitchen-sink/src/ensemble/screens/help.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/help.yaml
@@ -32,6 +32,14 @@ View:
             styles:
               names: heading-1
             text: Help
+        - Button:
+            styles:
+              className: page-1 ${ensemble.storage.get('zzz') + '-' + ensemble.storage.get('aaa')}
+            label: ${productTitleName}
+            onTap:
+              executeCode: |
+                // Calls a function defined in test.js
+                sayHello();
         - Markdown:
             text: More to come! In the meantime, checkout the Ensemble [documentation](https://docs.ensembleui.com/).
         - Card:

--- a/packages/framework/src/evaluate/evaluate.ts
+++ b/packages/framework/src/evaluate/evaluate.ts
@@ -38,14 +38,9 @@ export const buildEvaluateFn = (
       // Need to filter out invalid JS identifiers
     ].filter(([key, _]) => !key.includes(".")),
   );
-  const globalBlock = screen.model?.global;
-  const importedScriptBlock = screen.model?.importedScripts;
 
   // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-  const jsFunc = new Function(
-    ...Object.keys(invokableObj),
-    addScriptBlock(formatJs(js), globalBlock, importedScriptBlock),
-  );
+  const jsFunc = new Function(...Object.keys(invokableObj), formatJs(js));
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return () => jsFunc(...Object.values(invokableObj));
@@ -78,24 +73,6 @@ const formatJs = (js?: string): string => {
   }
 
   return `return ${sanitizedJs}`;
-};
-
-const addScriptBlock = (
-  js: string,
-  globalBlock?: string,
-  importedScriptBlock?: string,
-): string => {
-  let jsString = ``;
-
-  if (importedScriptBlock) {
-    jsString += `${importedScriptBlock}\n\n`;
-  }
-
-  if (globalBlock) {
-    jsString += `${globalBlock}\n\n`;
-  }
-
-  return (jsString += `${js}`);
 };
 
 /**

--- a/packages/runtime/src/runtime/screen.tsx
+++ b/packages/runtime/src/runtime/screen.tsx
@@ -91,6 +91,33 @@ export const EnsembleScreen: React.FC<EnsembleScreenProps> = ({
     };
   }, [screen.customWidgets]);
 
+  useEffect(() => {
+    const globalBlock = screen.global;
+    const importedScripts = screen.importedScripts;
+
+    if (!globalBlock && !importedScripts) {
+      return;
+    }
+
+    const jsString = `
+      ${importedScripts || ""}
+      ${globalBlock || ""}
+  `;
+
+    const script = document.createElement("script");
+    script.id = screen.id;
+    script.type = "text/javascript";
+    script.textContent = jsString;
+
+    document.body.appendChild(script);
+
+    console.log("<<<<<", window.global);
+
+    return () => {
+      document.getElementById(screen.id)?.remove();
+    };
+  }, [screen.global, screen.importedScripts]);
+
   if (!isInitialized) {
     return null;
   }


### PR DESCRIPTION
## Describe your changes
Add global or import scripts into DOM to reduce the load on buildEvaluateFunction

### Screenshots [Optional]

## Issue ticket number and link

Closes #1027 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
