### PR TITLE
feat: add selection column width property to DataGrid

### DIFF
--- a/.changeset/gorgeous-apes-sing.md
+++ b/.changeset/gorgeous-apes-sing.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+feat: add selection column width property to DataGrid

--- a/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/widgets.yaml
@@ -290,6 +290,7 @@ View:
                     executeCode: |
                       console.log("data", selectedRows, selectedRowKeys);
                   allowSelection: ${1===1}
+                  selectionColWidth: ${20+30}
                   selectionType: '${1===10 ? "checkbox" : "radio"}'
                   allowResizableColumns: true
                   defaultSelectedRowKeys: ["2"]

--- a/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
+++ b/packages/runtime/src/widgets/DataGrid/DataGrid.tsx
@@ -91,6 +91,7 @@ export interface DataGridScrollable {
 export type GridProps = {
   allowSelection?: boolean;
   selectionType?: "checkbox" | "radio";
+  selectionColWidth?: number;
   allowResizableColumns?: boolean;
   onRowsSelected?: EnsembleAction;
   defaultSelectedRowKeys?: string[];
@@ -178,6 +179,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
   const [selectionType, setSelectionType] = useState<"checkbox" | "radio">(
     props.selectionType ? props.selectionType : "checkbox",
   );
+  const selectionColWidth = props.selectionColWidth || 50;
   const containerRef = useRef<HTMLDivElement>(null);
   const { namedData } = useTemplateData({ ...itemTemplate });
   const components = {
@@ -314,6 +316,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
       rowsSelected,
       selectionType,
       allowSelection,
+      selectionColWidth,
       pageSize,
       curPage,
       widgetName,
@@ -474,6 +477,7 @@ export const DataGrid: React.FC<GridProps> = (props) => {
           rowSelection={
             allowSelection
               ? {
+                  columnWidth: values?.selectionColWidth,
                   type: selectionType,
                   onChange: (selectedRowKeys, selectedRows): void => {
                     setRowsKey(selectedRowKeys);


### PR DESCRIPTION
## Describe your changes

### Screenshots [Optional]
before adding `selectionColWidth` property
<img width="1577" alt="image" src="https://github.com/user-attachments/assets/550255ff-affa-4762-9986-054836e7d02e" />

after adding `selectionColWidth` property
<img width="1572" alt="image" src="https://github.com/user-attachments/assets/fcbacb6f-22be-4e14-8261-ed14e80c54c4" />

## Issue ticket number and link

Closes #1033 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [X] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
