### PR TITLE
use relative paths in app's manifest file

### DIFF
--- a/.changeset/modern-points-attack.md
+++ b/.changeset/modern-points-attack.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/js-commons": patch
+---
+
+use relative paths in app's manifest file

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -35,6 +35,7 @@ jobs:
           channelId: live
           projectId: ensemble-web-studio-dev
           entryPoint: ./apps/preview
+          firebaseToolsVersion: 13.35.1
       - name: Build Kitchen Sink
         run: pnpm run build
         working-directory: ./apps/kitchen-sink
@@ -45,3 +46,4 @@ jobs:
           channelId: live
           projectId: ensemble-web-studio-dev
           entryPoint: ./apps/kitchen-sink
+          firebaseToolsVersion: 13.35.1

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -30,3 +30,4 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ENSEMBLE_WEB_STUDIO_DEV }}"
           projectId: ensemble-web-studio-dev
           entryPoint: ./apps/kitchen-sink
+          firebaseToolsVersion: 13.35.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           channelId: live
           projectId: ensemble-web-studio
           entryPoint: ./apps/preview
+          firebaseToolsVersion: 13.35.1
       - name: Package Starter
         working-directory: ./apps/starter
         run: |


### PR DESCRIPTION
## Describe your changes
1.
Remove `projectPath` from `.manifest` file of an app
Fetch projectPath value from global manifest file

2.
https://github.com/FirebaseExtended/action-hosting-deploy#firebasetoolsversion-string
https://github.com/firebase/firebase-tools/releases
### Screenshots [Optional]

## Issue ticket number and link

Closes https://github.com/EnsembleUI/ensemble-web-studio/issues/1617

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
