### PR TITLE
optimize useWidgetId hook by utilizing latest and greatest createBindingAtom

### DIFF
--- a/.changeset/gold-pans-fry.md
+++ b/.changeset/gold-pans-fry.md
@@ -1,0 +1,5 @@
+---
+"@ensembleui/react-framework": patch
+---
+
+optimize useWidgetId hook by utilizing latest and greatest createBindingAtom

--- a/packages/framework/src/hooks/useWidgetId.ts
+++ b/packages/framework/src/hooks/useWidgetId.ts
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
+import { atom, useAtomValue } from "jotai";
 import type { Expression } from "../shared";
-import { error, isExpression } from "../shared";
-import { evaluate } from "../evaluate/evaluate";
-import { defaultScreenContext } from "../state";
+import { deepCloneAsJSON, error, isExpression } from "../shared";
+import { createBindingAtom } from "../evaluate";
 import { useCustomScope } from "./useCustomScope";
 
 export const useWidgetId = (
@@ -13,30 +13,45 @@ export const useWidgetId = (
   resolvedTestId: string | undefined;
 } => {
   const customScope = useCustomScope();
-  const resolvedWidgetId = useMemo<string>(() => {
-    let workingId = id;
-    if (isExpression(workingId)) {
-      workingId = String(
-        evaluate(defaultScreenContext, workingId, customScope),
+
+  const idBindingAtom = useMemo(() => {
+    if (isExpression(id)) {
+      return createBindingAtom(
+        id,
+        deepCloneAsJSON(customScope) || {},
+        "widgetId",
       );
     }
-    if (workingId && JS_ID_REGEX.test(workingId)) {
-      return workingId;
+    return atom<string | undefined>(id);
+  }, [customScope, id]);
+
+  const resolvedId = useAtomValue(idBindingAtom);
+
+  const resolvedWidgetId = useMemo<string>(() => {
+    const workingId = resolvedId;
+    if (workingId && JS_ID_REGEX.test(String(workingId))) {
+      return String(workingId);
     }
     if (workingId) {
       error(
-        `${workingId} is not a valid javascript identifier. generating a random one`,
+        `${String(workingId)} is not a valid javascript identifier. generating a random one`,
       );
     }
     return generateRandomString(6);
-  }, [customScope, id]);
+  }, [resolvedId]);
 
-  const resolvedTestId = useMemo(() => {
+  const testIdBindingAtom = useMemo(() => {
     if (isExpression(testId)) {
-      return String(evaluate(defaultScreenContext, testId, customScope));
+      return createBindingAtom(
+        testId,
+        deepCloneAsJSON(customScope) || {},
+        "widgetTestId",
+      );
     }
-    return testId;
+    return atom<string | undefined>(testId);
   }, [customScope, testId]);
+
+  const resolvedTestId = useAtomValue(testIdBindingAtom) as string | undefined;
 
   return { resolvedWidgetId, resolvedTestId };
 };


### PR DESCRIPTION
## Describe your changes
Problem:
When using any method/value from an imported/global script in `id` of any widget, it throws an error

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added tests
- [ ] I have added a changeset `pnpm changeset add`
- [ ] I have added example usage in the kitchen sink app
