### PR TITLE
add support in Dropdown for creating new options using allowCreateOptions prop

### DIFF
--- a/.changeset/quiet-bulldogs-tan.md
+++ b/.changeset/quiet-bulldogs-tan.md
@@ -1,0 +1,6 @@
+---
+"@ensembleui/react-kitchen-sink": patch
+"@ensembleui/react-runtime": patch
+---
+
+add support in Dropdown for creating new options using allowCreateOptions prop

--- a/apps/kitchen-sink/src/ensemble/screens/forms.yaml
+++ b/apps/kitchen-sink/src/ensemble/screens/forms.yaml
@@ -165,6 +165,20 @@ View:
                         onChange:
                           executeCode: |
                             console.log('dropdown changed', value);
+                    - Dropdown:
+                        id: dropdownWithCreateOptions
+                        label: Dropdown with create options
+                        hintText: Try typing "New Option"
+                        allowCreateOptions: true
+                        value: option2
+                        items:
+                          - label: Option 1
+                            value: option1
+                          - label: Option 2
+                            value: option2
+                        onChange:
+                          executeCode: |
+                            console.log('dropdownWithCreateOptions changed', value);
                     # If you omit id, the form value key will be the label
                     - TextInput:
                         id: formTextInput

--- a/packages/runtime/src/widgets/Form/Form.tsx
+++ b/packages/runtime/src/widgets/Form/Form.tsx
@@ -6,7 +6,7 @@ import {
 import { Form as AntForm } from "antd";
 import type { FormProps as AntFormProps } from "antd";
 import { useCallback, useState } from "react";
-import type { FormLayout } from "antd/es/form/Form";
+import type { FormInstance, FormLayout } from "antd/es/form/Form";
 import { set } from "lodash-es";
 import { WidgetRegistry } from "../../registry";
 import { EnsembleRuntime } from "../../runtime";
@@ -129,3 +129,44 @@ const getLayout = (labelPosition?: string): FormLayout => {
 };
 
 WidgetRegistry.register(widgetName, Form);
+
+/**
+ * Programmatically update the value of a field and trigger Ant Design's `onFieldsChange`
+ * (or Ensemble Form's `onChange` action).
+ *
+ * Normally, calling `form.setFieldValue` or `form.setFieldsValue` does not fire `onFieldsChange`.
+ * This helper uses Ant Design's internal `dispatch` mechanism to register the update
+ * as if it were user-driven, so that `onFieldsChange` fires consistently.
+ *
+ * This is especially useful for widgets that update values programmatically
+ * (e.g. Dropdown with `allowCreateOptions`).
+ *
+ * Alternatively, one could use Ant Design's `Form.useWatch`, but this approach
+ * is less performant for large forms.
+ *
+ * ⚠️ Relies on Ant Design's private API (`RC_FORM_INTERNAL_HOOKS`), which may change
+ * in future versions.
+ *
+ * Reference: https://github.com/ant-design/ant-design/issues/23782#issuecomment-2114700558
+ */
+export function updateFieldValue<Values>(
+  form: FormInstance<Values>,
+  name: string,
+  value: unknown,
+): void {
+  type InternalForm = FormInstance<Values> & {
+    getInternalHooks: (hook: string) => {
+      dispatch: (action: {
+        type: string;
+        namePath: string[];
+        value: unknown;
+      }) => void;
+    };
+  };
+
+  (form as InternalForm).getInternalHooks("RC_FORM_INTERNAL_HOOKS").dispatch({
+    type: "updateValue",
+    namePath: [name],
+    value,
+  });
+}

--- a/packages/runtime/src/widgets/Form/__tests__/Dropdown.test.tsx
+++ b/packages/runtime/src/widgets/Form/__tests__/Dropdown.test.tsx
@@ -198,5 +198,112 @@ describe("Dropdown Widget", () => {
       );
     });
   });
+
+  test("allows creating new options when allowCreateOptions is enabled", async () => {
+    render(
+      <Form
+        children={[
+          {
+            name: "Dropdown",
+            properties: {
+              id: "createOptions",
+              label: "Select or Create",
+              items: [
+                { label: "Option 1", value: "option1" },
+                { label: "Option 2", value: "option2" },
+              ],
+              allowCreateOptions: true,
+            },
+          },
+          ...defaultFormButton,
+        ]}
+        id="form"
+      />,
+      { wrapper: FormTestWrapper },
+    );
+
+    const dropdown = screen.getByRole("combobox");
+    userEvent.click(dropdown);
+
+    // Type a new option
+    userEvent.type(dropdown, "New Option");
+
+    // Check if the "Add" option appears
+    await waitFor(() => {
+      expect(screen.getByText('Add "New Option"')).toBeInTheDocument();
+    });
+
+    // Click on the "Add" button to create and select the option
+    const addButton = screen.getByText('Add "New Option"');
+    fireEvent.click(addButton);
+
+    // Check if the new option was selected (should show in the input)
+    await waitFor(() => {
+      expect(dropdown).toHaveValue("New Option");
+    });
+
+    // Close the dropdown and reopen it to verify the new option persists
+    userEvent.click(dropdown);
+    await waitFor(() => {
+      expect(screen.getByText("New Option")).toBeInTheDocument();
+    });
+  });
+
+  test("triggers Form onChange when creating new options", async () => {
+    render(
+      <Form
+        children={[
+          {
+            name: "Dropdown",
+            properties: {
+              id: "createOptions",
+              label: "Select or Create",
+              items: [
+                { label: "Option 1", value: "option1" },
+                { label: "Option 2", value: "option2" },
+              ],
+              allowCreateOptions: true,
+            },
+          },
+          ...defaultFormButton,
+        ]}
+        id="form"
+        onChange={{
+          executeCode: "console.log('Form onChange triggered', fields)",
+        }}
+      />,
+      { wrapper: FormTestWrapper },
+    );
+
+    const dropdown = screen.getByRole("combobox");
+    userEvent.click(dropdown);
+
+    // Type a new option
+    userEvent.type(dropdown, "Custom Option");
+
+    // Check if the "Add" option appears
+    await waitFor(() => {
+      expect(screen.getByText('Add "Custom Option"')).toBeInTheDocument();
+    });
+
+    // Click on the "Add" button to create and select the option
+    const addButton = screen.getByText('Add "Custom Option"');
+    fireEvent.click(addButton);
+
+    // Check if the new option was selected
+    await waitFor(() => {
+      expect(dropdown).toHaveValue("Custom Option");
+    });
+
+    // Verify that the Form's onChange was triggered
+    await waitFor(() => {
+      expect(logSpy).toHaveBeenCalledWith(
+        "Form onChange triggered",
+        expect.objectContaining({
+          createOptions: "Custom Option",
+        }),
+      );
+    });
+  });
 });
 /* eslint-enable react/no-children-prop */


### PR DESCRIPTION
## Describe your changes
- Added support in the **Dropdown** widget for creating new options via the `allowCreateOptions` prop.  
- When a user types a new option, it is now added to the dropdown and selected automatically.  
- To ensure the form's `onChange` (or Ant Design's `onFieldsChange`) fires consistently, we introduced a helper that leverages Ant Design's internal `RC_FORM_INTERNAL_HOOKS.dispatch`.  

⚠️ **Note:** This relies on Ant Design’s private API (`RC_FORM_INTERNAL_HOOKS`), which may change in future versions.  
Alternative approaches like `Form.useWatch` were considered, but were rejected due to performance trade-offs.  
This implementation keeps the change localized to the Dropdown widget and avoids diffing the entire form on every update.  

### Screenshots [Optional]

https://github.com/user-attachments/assets/97cc7ad3-aa79-4368-b89a-bc489450ba95


## Issue ticket number and link

Closes #1103 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests
- [x] I have added a changeset `pnpm changeset add`
- [x] I have added example usage in the kitchen sink app
